### PR TITLE
Add support for accessing quotas and features

### DIFF
--- a/src/application/cli/command/template/create.ts
+++ b/src/application/cli/command/template/create.ts
@@ -72,7 +72,14 @@ export class CreateTemplateCommand implements Command<CreateTemplateInput> {
             $schema: 'https://schema.croct.com/json/v1/template.json',
             title: 'My template',
             actions: empty
-                ? []
+                ? [
+                    {
+                        name: 'print',
+                        semantic: 'info',
+                        title: 'Empty template',
+                        message: 'Edit this template to define your actions.',
+                    },
+                ]
                 : [
                     {
                         name: 'create-resource',

--- a/src/infrastructure/application/cli/cli.ts
+++ b/src/infrastructure/application/cli/cli.ts
@@ -1223,6 +1223,24 @@ export class Cli {
 
         return {
             project: {
+                features: LazyPromise.transient(async () => {
+                    const {organization, workspace} = await this.getConfigurationManager().load();
+                    const {features} = await this.getWorkspaceApi().getFeatures({
+                        organizationSlug: organization,
+                        workspaceSlug: workspace,
+                    }) ?? {};
+
+                    return features ?? {};
+                }),
+                quotas: LazyPromise.transient(async () => {
+                    const {organization, workspace} = await this.getConfigurationManager().load();
+                    const {quotas} = await this.getWorkspaceApi().getFeatures({
+                        organizationSlug: organization,
+                        workspaceSlug: workspace,
+                    }) ?? {};
+
+                    return quotas ?? {};
+                }),
                 organization: LazyPromise.transient(
                     async () => {
                         const {organization} = await this.getConfigurationManager().load();


### PR DESCRIPTION
## Summary
This PR adds support for accessing information about available quotas and features within a template. This allows templates to conditionally adjust their behavior based on the project's capabilities. For example, a template that relies on dynamic content could provide a fallback variation using CQL, enabling graceful feature degradation when necessary.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings