### PR TITLE
Support URL-like deep links

### DIFF
--- a/src/application/cli/command/open.ts
+++ b/src/application/cli/command/open.ts
@@ -146,7 +146,7 @@ export class OpenCommand implements Command<OpenInput> {
     private parseArguments(url: URL): string[] {
         const args: string[] = [];
 
-        for (const segment of url.pathname.split('/')) {
+        for (const segment of (url.hostname + url.pathname).split('/')) {
             if (segment !== '') {
                 args.push(segment);
             }
@@ -178,7 +178,6 @@ export class OpenCommand implements Command<OpenInput> {
 
     private isValidUrl(url: URL): boolean {
         return url.protocol === `${this.config.protocol}:`
-            && url.hostname === ''
             && url.username === ''
             && url.password === ''
             && url.port === ''


### PR DESCRIPTION
## Summary
Currently, only croct: and croct:/ links are supported. This PR updates the logic to also support croct://, which is the format most softwares (e.g: Slack) and websites expect to recognize a clickable link.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings