### PR TITLE
Fix selection of falsy values

### DIFF
--- a/src/infrastructure/application/cli/io/consoleInput.ts
+++ b/src/infrastructure/application/cli/io/consoleInput.ts
@@ -51,23 +51,25 @@ export class ConsoleInput implements Input {
             ? selection.options.findIndex(option => option.value === selection.default)
             : -1;
 
-        return this.interact({
+        return this.interact<string, string>({
             type: selection.options.length > 10 ? 'autocomplete' : 'select',
             instructions: false,
             message: selection.message,
             choices: selection.options.map(
-                option => ({
+                (option, index) => ({
                     title: option.label,
-                    value: option.value,
+                    // Prompts returns the label for falsy values:
+                    // https://github.com/terkelg/prompts/issues/349
+                    value: `${index}`,
                     disabled: option.disabled,
                 }),
             ),
             initial: initial === -1 ? undefined : initial,
-        });
+        }).then(index => selection.options[Number.parseInt(index, 10)].value);
     }
 
     public selectMultiple<T>(selection: MultipleSelection<T>): Promise<T[]> {
-        return this.interact({
+        return this.interact<string, string[]>({
             type: selection.options.length > 10 ? 'autocompleteMultiselect' : 'multiselect',
             hint: '<space> to select. <a> to toggle all. <enter> to submit.',
             message: selection.message,
@@ -75,14 +77,14 @@ export class ConsoleInput implements Input {
             min: selection.min,
             max: selection.max,
             choices: selection.options.map(
-                option => ({
+                (option, index) => ({
                     title: option.label,
-                    value: option.value,
+                    value: `${index}`,
                     disabled: option.disabled,
                     selected: option.selected,
                 }),
             ),
-        });
+        }).then(indices => indices.map(index => selection.options[Number.parseInt(index, 10)].value));
     }
 
     public confirm(confirmation: Confirmation): Promise<boolean> {


### PR DESCRIPTION
## Summary
This PR fixes a bug where, for prompts expecting an empty string, the returned value incorrectly contains the label instead of an actual empty string. One example is the prompt shown when opening a deep link, which uses an empty string to indicate the current directory. Due to this bug, the CLI attempts to enter the current directory with the "(current)" suffix (used for presentation purposes). which doesn't exist, causing a crash.

The workaround here is to map the prompt’s internal values to the indices of the available choices, then remap them back to their original values before returning them to the calling function.

For more details, see the associated [bug report](https://github.com/terkelg/prompts/issues/349).

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings