### PR TITLE
Fix content map generation

### DIFF
--- a/src/application/project/sdk/javasScriptSdk.ts
+++ b/src/application/project/sdk/javasScriptSdk.ts
@@ -362,8 +362,8 @@ export abstract class JavaScriptSdk implements Sdk {
                 const defaultLocale = ${JSON.stringify(configuration.defaultLocale)};
 
                 export function getSlotContent(slotId, language = defaultLocale) {
-                    if (contentEntries[language]?.[slotId] !== undefined) {
-                        return contentEntries[language][slotId];
+                    if (contentMap[language]?.[slotId] !== undefined) {
+                        return contentMap[language][slotId];
                     }
 
                     if (language !== defaultLocale) {
@@ -391,8 +391,8 @@ export abstract class JavaScriptSdk implements Sdk {
 
                 module.exports = {
                     getSlotContent: function getSlotContent(slotId, language = defaultLocale) {
-                        if (contentEntries[language]?.[slotId] !== undefined) {
-                            return contentEntries[language][slotId];
+                        if (contentMap[language]?.[slotId] !== undefined) {
+                            return contentMap[language][slotId];
                         }
 
                         if (language !== defaultLocale) {
@@ -418,8 +418,8 @@ export abstract class JavaScriptSdk implements Sdk {
                 const defaultLocale = ${JSON.stringify(configuration.defaultLocale)};
 
                 export function loadSlotContent(slotId, language = defaultLocale) {
-                    if (contentEntries[language]?.[slotId] !== undefined) {
-                        return contentEntries[language][slotId]().then(module => module.default);
+                    if (contentMap[language]?.[slotId] !== undefined) {
+                        return contentMap[language][slotId]().then(module => module.default);
                     }
 
                     if (language !== defaultLocale) {
@@ -445,8 +445,8 @@ export abstract class JavaScriptSdk implements Sdk {
 
                 module.exports = {
                     loadSlotContent: function loadSlotContent(slotId, language = defaultLocale) {
-                        if (contentEntries[language]?.[slotId] !== undefined) {
-                            return contentEntries[language][slotId]().then(module => module.default);
+                        if (contentMap[language]?.[slotId] !== undefined) {
+                            return contentMap[language][slotId]().then(module => module.default);
                         }
 
                         if (language !== defaultLocale) {


### PR DESCRIPTION
## Summary
This PR fixes an error in the CLI where a function references the `contentEntries` variable despite the actual variable being named `contentMap`.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings