### PR TITLE
Add Firefox profile workaround on macOS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "fast-equals": "^5.1.3",
         "gunzip-maybe": "^1.4.2",
         "ignore": "^7.0.3",
+        "ini": "^5.0.0",
         "is-plain-obj": "^4.1.0",
         "is-unicode-supported": "^2.1.0",
         "jsep": "^1.4.0",
@@ -57,6 +58,7 @@
         "@graphql-codegen/cli": "^5.0.2",
         "@swc/jest": "^0.2.36",
         "@types/gunzip-maybe": "^1.4.2",
+        "@types/ini": "^4.1.1",
         "@types/jest": "^29.0.0",
         "@types/prompts": "^2.4.9",
         "@types/tar-stream": "^3.1.3",
@@ -3627,6 +3629,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/ini": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@types/ini/-/ini-4.1.1.tgz",
+      "integrity": "sha512-MIyNUZipBTbyUNnhvuXJTY7B6qNI78meck9Jbv3wk0OgNwRyOOVEKDutAkOs1snB/tx0FafyR6/SN4Ps0hZPeg==",
+      "dev": true
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -8211,6 +8219,14 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ini": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-5.0.0.tgz",
+      "integrity": "sha512-+N0ngpO3e7cRUWOJAS7qw0IZIVc6XPrW4MlFBdD066F2L4k1L6ker3hLqSq7iXxU5tgS4WGkIUElWn5vogAEnw==",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
     },
     "node_modules/inquirer": {
       "version": "8.2.6",

--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
     "graphql-codegen": "graphql-codegen --config codegen.ts"
   },
   "dependencies": {
+    "@babel/core": "^7.25.7",
     "@babel/generator": "^7.25.9",
     "@babel/parser": "^7.25.7",
-    "@babel/core": "^7.25.7",
     "@babel/types": "^7.25.9",
     "@croct/cache": "^0.4.2",
     "@croct/content": "^1.0.0",
@@ -56,6 +56,7 @@
     "fast-equals": "^5.1.3",
     "gunzip-maybe": "^1.4.2",
     "ignore": "^7.0.3",
+    "ini": "^5.0.0",
     "is-plain-obj": "^4.1.0",
     "is-unicode-supported": "^2.1.0",
     "jsep": "^1.4.0",
@@ -78,6 +79,7 @@
     "@graphql-codegen/cli": "^5.0.2",
     "@swc/jest": "^0.2.36",
     "@types/gunzip-maybe": "^1.4.2",
+    "@types/ini": "^4.1.1",
     "@types/jest": "^29.0.0",
     "@types/prompts": "^2.4.9",
     "@types/tar-stream": "^3.1.3",

--- a/src/application/cli/command/welcome.ts
+++ b/src/application/cli/command/welcome.ts
@@ -53,6 +53,8 @@ export class WelcomeCommand implements Command<WelcomeInput> {
             packageManager.isInstalled(),
         ]);
 
+        await registry.unregister('croct');
+
         if (isRegistered || !isPackageManagerInstalled) {
             return;
         }

--- a/src/application/cli/command/welcome.ts
+++ b/src/application/cli/command/welcome.ts
@@ -53,8 +53,6 @@ export class WelcomeCommand implements Command<WelcomeInput> {
             packageManager.isInstalled(),
         ]);
 
-        await registry.unregister('croct');
-
         if (isRegistered || !isPackageManagerInstalled) {
             return;
         }

--- a/src/application/system/process/process.ts
+++ b/src/application/system/process/process.ts
@@ -9,7 +9,7 @@ export interface ProcessObserver extends EventObserver<ProcessEvents> {
 }
 
 export interface Process extends ProcessObserver {
-    getPlatform(): string;
+    getPlatform(): Process.Platform;
     getCurrentDirectory(): string;
     getStandardInput(): Readable;
     getStandardOutput(): Writable;
@@ -18,4 +18,8 @@ export interface Process extends ProcessObserver {
     getEnvList(name: string): string[] | null;
     changeDirectory(directory: string): void;
     exit(exitCode?: number): Promise<never>;
+}
+
+export namespace Process {
+    export type Platform = NodeJS.Platform;
 }

--- a/src/application/system/protocol/failSafeRegistry.ts
+++ b/src/application/system/protocol/failSafeRegistry.ts
@@ -1,0 +1,37 @@
+import {ProtocolHandler, ProtocolRegistry, ProtocolRegistryError} from '@/application/system/protocol/protocolRegistry';
+
+export class FailSafeRegistry implements ProtocolRegistry {
+    private readonly registry: ProtocolRegistry;
+
+    public constructor(registry: ProtocolRegistry) {
+        this.registry = registry;
+    }
+
+    public isRegistered(protocol: string): Promise<boolean> {
+        return this.registry.isRegistered(protocol);
+    }
+
+    public async register(handler: ProtocolHandler): Promise<void> {
+        try {
+            await this.registry.register(handler);
+        } catch (error) {
+            this.handleError(error);
+        }
+    }
+
+    public async unregister(protocol: string): Promise<void> {
+        try {
+            await this.registry.unregister(protocol);
+        } catch (error) {
+            this.handleError(error);
+        }
+    }
+
+    private handleError(error: any): void {
+        if (!(error instanceof ProtocolRegistryError)) {
+            throw error;
+        }
+
+        throw error;
+    }
+}

--- a/src/application/system/protocol/failSafeRegistry.ts
+++ b/src/application/system/protocol/failSafeRegistry.ts
@@ -15,7 +15,7 @@ export class FailSafeRegistry implements ProtocolRegistry {
         try {
             await this.registry.register(handler);
         } catch (error) {
-            this.handleError(error);
+            FailSafeRegistry.handleError(error);
         }
     }
 
@@ -23,15 +23,13 @@ export class FailSafeRegistry implements ProtocolRegistry {
         try {
             await this.registry.unregister(protocol);
         } catch (error) {
-            this.handleError(error);
+            FailSafeRegistry.handleError(error);
         }
     }
 
-    private handleError(error: any): void {
+    private static handleError(error: any): void {
         if (!(error instanceof ProtocolRegistryError)) {
             throw error;
         }
-
-        throw error;
     }
 }

--- a/src/application/system/protocol/firefoxRegistry.ts
+++ b/src/application/system/protocol/firefoxRegistry.ts
@@ -1,0 +1,250 @@
+import {parse} from 'ini';
+import {ProtocolHandler, ProtocolRegistry, ProtocolRegistryError} from '@/application/system/protocol/protocolRegistry';
+import {FileSystem} from '@/application/fs/fileSystem';
+import {ErrorReason} from '@/application/error';
+import {Process} from '@/application/system/process/process';
+
+export type Configuration = {
+    fileSystem: FileSystem,
+    appDirectory: string,
+};
+
+export type PartialConfiguration = Pick<Configuration, 'fileSystem'>;
+
+export type MacOsConfiguration = PartialConfiguration & {
+    homeDirectory: string,
+};
+
+export type WindowsConfiguration = PartialConfiguration & {
+    appDataDirectory: string,
+};
+
+export type LinuxConfiguration = PartialConfiguration & {
+    homeDirectory: string,
+};
+
+export class FirefoxRegistry implements ProtocolRegistry {
+    private static readonly PREFERENCES = [
+        'user_pref("network.protocol-handler.expose.%protocol%", false);',
+        'user_pref("network.protocol-handler.external.%protocol%", true);',
+    ];
+
+    private readonly fileSystem: FileSystem;
+
+    private readonly profileDirectory: string;
+
+    public constructor({fileSystem, appDirectory}: Configuration) {
+        this.fileSystem = fileSystem;
+        this.profileDirectory = appDirectory;
+    }
+
+    public static fromSystem(process: Process, configuration: PartialConfiguration): FirefoxRegistry {
+        switch (process.getPlatform()) {
+            case 'win32': {
+                const dataDirectory = process.getEnvValue('APPDATA') ?? process.getEnvValue('USERPROFILE');
+
+                if (dataDirectory === null) {
+                    throw new ProtocolRegistryError('Cannot determine the user profile directory.', {
+                        reason: ErrorReason.PRECONDITION,
+                    });
+                }
+
+                return FirefoxRegistry.windows({
+                    fileSystem: configuration.fileSystem,
+                    appDataDirectory: dataDirectory,
+                });
+            }
+
+            case 'darwin': {
+                const home = process.getEnvValue('HOME');
+
+                if (home === null) {
+                    throw new ProtocolRegistryError('Cannot determine the user home directory.', {
+                        reason: ErrorReason.PRECONDITION,
+                    });
+                }
+
+                return FirefoxRegistry.macOs({
+                    fileSystem: configuration.fileSystem,
+                    homeDirectory: home,
+                });
+            }
+
+            case 'linux': {
+                const home = process.getEnvValue('HOME');
+
+                if (home === null) {
+                    throw new ProtocolRegistryError('Cannot determine the user home directory.', {
+                        reason: ErrorReason.PRECONDITION,
+                    });
+                }
+
+                return FirefoxRegistry.linux({
+                    fileSystem: configuration.fileSystem,
+                    homeDirectory: home,
+                });
+            }
+
+            default:
+                throw new ProtocolRegistryError(`Platform \`${process.getPlatform()}\` is not supported.`, {
+                    reason: ErrorReason.NOT_SUPPORTED,
+                });
+        }
+    }
+
+    public static windows(configuration: WindowsConfiguration): FirefoxRegistry {
+        return new FirefoxRegistry({
+            fileSystem: configuration.fileSystem,
+            appDirectory: configuration.fileSystem.joinPaths(
+                configuration.appDataDirectory,
+                'Mozilla',
+                'Firefox',
+            ),
+        });
+    }
+
+    public static macOs(configuration: MacOsConfiguration): FirefoxRegistry {
+        return new FirefoxRegistry({
+            fileSystem: configuration.fileSystem,
+            appDirectory: configuration.fileSystem.joinPaths(
+                configuration.homeDirectory,
+                'Library',
+                'Application Support',
+                'Firefox',
+            ),
+        });
+    }
+
+    public static linux(configuration: LinuxConfiguration): FirefoxRegistry {
+        return new FirefoxRegistry({
+            fileSystem: configuration.fileSystem,
+            appDirectory: configuration.fileSystem.joinPaths(
+                configuration.homeDirectory,
+                'snap',
+                'firefox',
+                'common',
+                '.mozilla',
+                'firefox',
+            ),
+        });
+    }
+
+    public async isRegistered(protocol: string): Promise<boolean> {
+        const preferencesPath = await this.getPreferencesFilePath();
+
+        if (preferencesPath === null) {
+            return false;
+        }
+
+        const preferences = await this.fileSystem
+            .readTextFile(preferencesPath)
+            .catch(() => '');
+
+        for (const preference of this.getPreferences(protocol)) {
+            if (!preferences.includes(preference)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public async register(handler: ProtocolHandler): Promise<void> {
+        if (await this.isRegistered(handler.protocol)) {
+            return;
+        }
+
+        const preferencesPath = await this.getPreferencesFilePath();
+
+        if (preferencesPath === null) {
+            throw new ProtocolRegistryError('Cannot find the default profile file.', {
+                reason: ErrorReason.PRECONDITION,
+            });
+        }
+
+        const preferences = await this.fileSystem
+            .readTextFile(preferencesPath)
+            .catch(() => '');
+
+        const newPreferences = `${preferences}\n${this.getPreferences(handler.protocol).join('\n')}`;
+
+        await this.fileSystem.writeTextFile(preferencesPath, newPreferences, {
+            overwrite: true,
+        });
+    }
+
+    public async unregister(protocol: string): Promise<void> {
+        if (!await this.isRegistered(protocol)) {
+            return;
+        }
+
+        const preferencesPath = await this.getPreferencesFilePath();
+
+        if (preferencesPath === null) {
+            return;
+        }
+
+        const preferences = await this.fileSystem
+            .readTextFile(preferencesPath)
+            .catch(() => '');
+
+        const newPreferences = preferences
+            .split('\n')
+            .filter(line => !this.getPreferences(protocol).includes(line))
+            .join('\n');
+
+        await this.fileSystem.writeTextFile(preferencesPath, newPreferences, {
+            overwrite: true,
+        });
+    }
+
+    private async getPreferencesFilePath(): Promise<string|null> {
+        const profilesIniPath = this.getPath('profiles.ini');
+
+        if (!await this.fileSystem.exists(profilesIniPath)) {
+            return null;
+        }
+
+        const sections = Object.values(parse(await this.fileSystem.readTextFile(profilesIniPath)));
+        const defaults: string[] = [];
+        const paths: string[] = [];
+
+        for (const section of sections) {
+            if (section.Default !== undefined) {
+                defaults.push(section.Default);
+            }
+
+            if (section.Path !== undefined) {
+                if (section.Default === '1') {
+                    paths.unshift(section.Path);
+                } else {
+                    paths.push(section.Path);
+                }
+            }
+        }
+
+        if (paths.length === 0) {
+            return null;
+        }
+
+        let resolvedPath = paths[0];
+
+        for (const path of paths) {
+            if (defaults.includes(path)) {
+                resolvedPath = path;
+
+                break;
+            }
+        }
+
+        return this.getPath(this.fileSystem.joinPaths(resolvedPath, 'user.js'));
+    }
+
+    private getPath(path: string): string {
+        return this.fileSystem.joinPaths(this.profileDirectory, path);
+    }
+
+    private getPreferences(protocolName: string): string[] {
+        return FirefoxRegistry.PREFERENCES.map(preference => preference.replace(/%protocol%/g, protocolName));
+    }
+}

--- a/src/application/system/protocol/linuxRegistry.ts
+++ b/src/application/system/protocol/linuxRegistry.ts
@@ -32,9 +32,7 @@ export class LinuxRegistry implements ProtocolRegistry {
 
     public async register(handler: ProtocolHandler): Promise<void> {
         if (await this.isRegistered(handler.protocol)) {
-            throw new ProtocolRegistryError(`Protocol \`${handler.protocol}\` is already registered.`, {
-                reason: ErrorReason.PRECONDITION,
-            });
+            return;
         }
 
         try {

--- a/src/application/system/protocol/macOsRegistry.ts
+++ b/src/application/system/protocol/macOsRegistry.ts
@@ -30,9 +30,7 @@ export class MacOsRegistry implements ProtocolRegistry {
 
     public async register(handler: ProtocolHandler): Promise<void> {
         if (await this.isRegistered(handler.protocol)) {
-            throw new ProtocolRegistryError(`Protocol \`${handler.protocol}\` is already registered.`, {
-                reason: ErrorReason.PRECONDITION,
-            });
+            return;
         }
 
         try {

--- a/src/application/system/protocol/multiRegistry.ts
+++ b/src/application/system/protocol/multiRegistry.ts
@@ -1,0 +1,37 @@
+import {ProtocolHandler, ProtocolRegistry} from '@/application/system/protocol/protocolRegistry';
+import {FileSystem} from '@/application/fs/fileSystem';
+
+export type Configuration = {
+    fileSystem: FileSystem,
+    appDirectory: string,
+};
+
+export class MultiRegistry implements ProtocolRegistry {
+    private readonly registries: ProtocolRegistry[];
+
+    public constructor(...registries: ProtocolRegistry[]) {
+        this.registries = registries;
+    }
+
+    public async isRegistered(protocol: string): Promise<boolean> {
+        for (const registry of this.registries) {
+            if (!await registry.isRegistered(protocol)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public async register(handler: ProtocolHandler): Promise<void> {
+        for (const registry of this.registries) {
+            await registry.register(handler);
+        }
+    }
+
+    public async unregister(protocol: string): Promise<void> {
+        for (const registry of this.registries) {
+            await registry.unregister(protocol);
+        }
+    }
+}

--- a/src/application/system/protocol/windowsRegistry.ts
+++ b/src/application/system/protocol/windowsRegistry.ts
@@ -20,9 +20,7 @@ export class WindowsRegistry implements ProtocolRegistry {
 
     public async register(handler: ProtocolHandler): Promise<void> {
         if (await this.isRegistered(handler.protocol)) {
-            throw new ProtocolRegistryError(`Protocol \`${handler.protocol}\` is already registered.`, {
-                reason: ErrorReason.PRECONDITION,
-            });
+            return;
         }
 
         try {

--- a/src/infrastructure/application/system/nodeProcess.ts
+++ b/src/infrastructure/application/system/nodeProcess.ts
@@ -24,7 +24,7 @@ export class NodeProcess implements Process {
         return this.getEnvValue(name)?.split(delimiter) ?? null;
     }
 
-    public getPlatform(): string {
+    public getPlatform(): Process.Platform {
         return process.platform;
     }
 


### PR DESCRIPTION
## Summary

This pull request adds a workaround specifically for Firefox on macOS. There is a [known bug](https://bugzilla.mozilla.org/show_bug.cgi?id=718422) in Firefox that prompts users to reselect the application whenever they open a URL. To work around this, we now configure the application within the Firefox profile. 

If Firefox is not installed or the profile directory is unavailable, the process gracefully fails without throwing errors, thanks to the `FailSafeRegistry`. 

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings