### PR TITLE
Optimize organization form

### DIFF
--- a/src/application/cli/form/organization/organizationForm.ts
+++ b/src/application/cli/form/organization/organizationForm.ts
@@ -30,11 +30,23 @@ export class OrganizationForm implements Form<Organization, OrganizationOptions>
         if (options.new !== true) {
             const notifier = output.notify('Loading organizations');
 
-            const organizations = await api.getOrganizations();
+            const organizations: Organization[] = [];
 
-            const defaultOrganization = OrganizationForm.getDefaultOrganization(organizations, options.default);
+            if (options.default !== undefined) {
+                const defaultOrganization = await api.getOrganization(options.default);
 
-            if (defaultOrganization !== null) {
+                if (defaultOrganization !== null) {
+                    organizations.push(defaultOrganization);
+                }
+            }
+
+            if (organizations.length === 0) {
+                organizations.push(...await api.getOrganizations());
+            }
+
+            if (organizations.length === 1) {
+                const defaultOrganization = organizations[0];
+
                 notifier.confirm(`Organization: ${defaultOrganization.name}`);
 
                 return defaultOrganization;
@@ -119,17 +131,5 @@ export class OrganizationForm implements Form<Organization, OrganizationOptions>
                 notifier.stop(persist);
             },
         };
-    }
-
-    private static getDefaultOrganization(organizations: Organization[], defaultSlug?: string): Organization | null {
-        if (organizations.length === 1) {
-            return organizations[0];
-        }
-
-        if (defaultSlug !== undefined) {
-            return organizations.find(({slug}) => slug === defaultSlug) ?? null;
-        }
-
-        return null;
     }
 }


### PR DESCRIPTION
## Summary
The backend requires specifying a record limit when fetching resources – there's no way to retrieve all of them. To work around this, the CLI uses a high limit (e.g., 100), which works fine for most resources like organizations, since users typically have one or just a few. However, support users can have access to hundreds of applications.

Previously, even when an organization was specified via a parameter, the CLI searched for it within the limited result set, which could fail if it wasn't included. This PR changes the logic so that when an organization is explicitly specified, the CLI fetches it directly, bypassing the limit.

The default behavior – listing organizations for selection – remains limited to the configured maximum.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings