### PR TITLE
Fix layout path resolution in Next.js SDK

### DIFF
--- a/src/application/project/sdk/plugNextSdk.ts
+++ b/src/application/project/sdk/plugNextSdk.ts
@@ -207,9 +207,15 @@ export class PlugNextSdk extends JavaScriptSdk {
             ),
             this.locateFile(
                 ...(project.router === 'app'
-                    ? [this.fileSystem.joinPaths('app', 'layout.jsx'), this.fileSystem.joinPaths('app', 'layout.tsx')]
-                    : [this.fileSystem.joinPaths('pages', '_app.jsx'), this.fileSystem.joinPaths('pages', '_app.tsx')]
-                ).map(file => this.fileSystem.joinPaths(project.sourceDirectory, file)),
+                    ? [this.fileSystem.joinPaths('app', 'layout'), this.fileSystem.joinPaths('app', 'layout')]
+                    : [this.fileSystem.joinPaths('pages', '_app'), this.fileSystem.joinPaths('pages', '_app')]
+                ).flatMap(
+                    file => (
+                        ['js', 'jsx', 'ts', 'tsx'].map(
+                            extension => this.fileSystem.joinPaths(project.sourceDirectory, `${file}.${extension}`),
+                        )
+                    ),
+                ),
             ),
         ]);
 
@@ -240,8 +246,8 @@ export class PlugNextSdk extends JavaScriptSdk {
                 file: providerComponentFile
                     ?? (
                         project.router === 'app'
-                            ? this.fileSystem.joinPaths('app', `layout.${extension}x`)
-                            : this.fileSystem.joinPaths('pages', `_app.${extension}x`)
+                            ? this.fileSystem.joinPaths(project.sourceDirectory, 'app', `layout.${extension}x`)
+                            : this.fileSystem.joinPaths(project.sourceDirectory, 'pages', `_app.${extension}x`)
                     ),
             },
         };


### PR DESCRIPTION
## Summary

This PR fixes a bug where the Next.js SDK failed to resolve the layout file when the project uses a `src` directory. The SDK was incorrectly pointing to the wrong folder when the layout could not be found.

Additionally, it was only checking for `jsx` and `tsx` extensions, ignoring `js` and `ts`. This PR updates the resolution logic to include all relevant extensions: `js`, `ts`, `jsx`, and `tsx`.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings