### PR TITLE
Rename options and add default default values to template

### DIFF
--- a/src/application/cli/command/template/create.ts
+++ b/src/application/cli/command/template/create.ts
@@ -71,6 +71,7 @@ export class CreateTemplateCommand implements Command<CreateTemplateInput> {
         return {
             $schema: 'https://schema.croct.com/json/v1/template.json',
             title: 'My template',
+            description: 'My template description',
             actions: empty
                 ? [
                     {

--- a/src/application/template/action/importAction.ts
+++ b/src/application/template/action/importAction.ts
@@ -194,15 +194,15 @@ export class ImportAction implements Action<ImportOptions> {
 
                 if (
                     definition.type === 'string'
-                    && definition.options !== undefined
-                    && !definition.options.includes(value as string)
+                    && definition.choices !== undefined
+                    && !definition.choices.includes(value as string)
                 ) {
                     throw new ActionError(
                         `Invalid value for option \`${name}\`.`,
                         {
                             reason: ErrorReason.INVALID_INPUT,
                             details: [
-                                `Allowed values: \`${definition.options.join('`, `')}\`.`,
+                                `Allowed values: \`${definition.choices.join('`, `')}\`.`,
                             ],
                         },
                     );

--- a/src/application/template/template.ts
+++ b/src/application/template/template.ts
@@ -12,7 +12,7 @@ type OptionTypes = {
     },
     string: {
         type: string,
-        options?: string[],
+        choices?: string[],
     },
     boolean: {
         type: boolean,

--- a/src/infrastructure/application/cli/program.ts
+++ b/src/infrastructure/application/cli/program.ts
@@ -301,8 +301,8 @@ function createProgram(config: Configuration): typeof program {
 
         switch (definition.type) {
             case 'string':
-                if (definition.options !== undefined && definition.options.length > 0) {
-                    option.choices(definition.options);
+                if (definition.choices !== undefined && definition.choices.length > 0) {
+                    option.choices(definition.choices);
                 }
 
                 break;

--- a/src/infrastructure/application/validation/templateValidator.ts
+++ b/src/infrastructure/application/validation/templateValidator.ts
@@ -25,7 +25,7 @@ const optionSchema: ZodType<OptionDefinition> = z.discriminatedUnion('type', [
     }),
     baseOptionSchema.extend({
         type: z.literal('string'),
-        options: z.array(z.string()).optional(),
+        choices: z.array(z.string()).optional(),
         default: z.string().optional(),
     }),
     baseOptionSchema.extend({

--- a/src/infrastructure/application/validation/templateValidator.ts
+++ b/src/infrastructure/application/validation/templateValidator.ts
@@ -46,16 +46,15 @@ const optionSchema: ZodType<OptionDefinition> = z.discriminatedUnion('type', [
     }),
 ]);
 
+const optionName = z.string()
+    .regex(/^[a-zA-Z0-9_]+$/)
+    .min(1);
+
 const templateSchema: ZodType<Template> = z.strictObject({
     $schema: z.string().optional(),
-    title: z.string()
-        .min(1)
-        .optional(),
-    description: z.string().optional(),
-    options: z.record(
-        z.string().min(1),
-        optionSchema,
-    ).optional(),
+    title: z.string().min(1),
+    description: z.string().min(1),
+    options: z.record(optionName, optionSchema).optional(),
     actions: z.array(z.any()),
 });
 


### PR DESCRIPTION
## Summary

This PR renames the `options` property in string options to `choices` to reduce ambiguity. It also makes `title` and `description` required fields for templates. Additionally, it enforces that option names follow the `/^[a-zA-Z0-9_]+$/` pattern to ensure compatibility with terminal command options.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings