### PR TITLE
Add support for overriding files

### DIFF
--- a/src/application/template/action/downloadAction.ts
+++ b/src/application/template/action/downloadAction.ts
@@ -12,7 +12,7 @@ export type DownloadOptions = {
     source: string,
     filter?: string,
     destination: string,
-    override?: boolean,
+    overwrite?: boolean,
     result?: {
         destination?: string,
     },
@@ -65,7 +65,7 @@ export class DownloadAction implements Action<DownloadOptions> {
 
     private async download(url: URL, options: DownloadOptions, input?: Input): Promise<void> {
         const {provider, fileSystem, codemod} = this.config;
-        const {destination, override = false} = options;
+        const {destination, overwrite = false} = options;
         const matcher = options.filter !== undefined
             ? new Minimatch(options.filter)
             : undefined;
@@ -109,7 +109,7 @@ export class DownloadAction implements Action<DownloadOptions> {
         if (await fileSystem.exists(destination)) {
             if (entries.length === 1 && entries[0].type === 'file') {
                 if (
-                    !override
+                    !overwrite
                     && await fileSystem.exists(entries[0].name)
                     && await input?.confirm({
                         message: `File ${entries[0].name} already exists. Do you want to overwrite it?`,
@@ -130,7 +130,7 @@ export class DownloadAction implements Action<DownloadOptions> {
                         suggestions: ['Delete the file'],
                     });
                 } else if (
-                    !override
+                    !overwrite
                     && !await fileSystem.isEmptyDirectory(destination)
                     && await input?.confirm({
                         message: `Directory ${destination} is not empty. Do you want to clear it?`,

--- a/src/application/template/action/downloadAction.ts
+++ b/src/application/template/action/downloadAction.ts
@@ -143,35 +143,37 @@ export class DownloadAction implements Action<DownloadOptions> {
                         suggestions: ['Delete the file'],
                     });
                 }
-            } else if (!await fileSystem.isDirectory(destination)) {
-                if (
-                    await input?.confirm({
-                        message: `Destination ${destination} is not a directory. Do you want to delete it?`,
+            } else {
+                if (!await fileSystem.isDirectory(destination)) {
+                    if (
+                        await input?.confirm({
+                            message: `Destination ${destination} is not a directory. Do you want to delete it?`,
+                            default: false,
+                        }) !== true
+                    ) {
+                        throw new ActionError('Destination is not a directory.', {
+                            reason: ErrorReason.PRECONDITION,
+                            details: [`Path: ${destination}`],
+                            suggestions: ['Delete the file'],
+                        });
+                    }
+                } else if (
+                    !overwrite
+                    && !await fileSystem.isEmptyDirectory(destination)
+                    && await input?.confirm({
+                        message: `Directory ${destination} is not empty. Do you want to clear it?`,
                         default: false,
                     }) !== true
                 ) {
-                    throw new ActionError('Destination is not a directory.', {
+                    throw new ActionError('Destination directory is not empty.', {
                         reason: ErrorReason.PRECONDITION,
-                        details: [`Path: ${destination}`],
-                        suggestions: ['Delete the file'],
+                        details: [`Directory: ${destination}`],
+                        suggestions: ['Clear the directory'],
                     });
                 }
-            } else if (
-                !overwrite
-                && !await fileSystem.isEmptyDirectory(destination)
-                && await input?.confirm({
-                    message: `Directory ${destination} is not empty. Do you want to clear it?`,
-                    default: false,
-                }) !== true
-            ) {
-                throw new ActionError('Destination directory is not empty.', {
-                    reason: ErrorReason.PRECONDITION,
-                    details: [`Directory: ${destination}`],
-                    suggestions: ['Clear the directory'],
-                });
-            }
 
-            await fileSystem.delete(destination, {recursive: true});
+                await fileSystem.delete(destination, {recursive: true});
+            }
         }
 
         return fileSystem.createDirectory(destination, {

--- a/src/application/template/action/downloadAction.ts
+++ b/src/application/template/action/downloadAction.ts
@@ -143,40 +143,38 @@ export class DownloadAction implements Action<DownloadOptions> {
                         suggestions: ['Delete the file'],
                     });
                 }
-            } else {
-                if (!await fileSystem.isDirectory(destination)) {
-                    if (
-                        await input?.confirm({
-                            message: `Destination ${destination} is not a directory. Do you want to delete it?`,
-                            default: false,
-                        }) !== true
-                    ) {
-                        throw new ActionError('Destination is not a directory.', {
-                            reason: ErrorReason.PRECONDITION,
-                            details: [`Path: ${destination}`],
-                            suggestions: ['Delete the file'],
-                        });
-                    }
-                } else if (
-                    !overwrite
-                    && !await fileSystem.isEmptyDirectory(destination)
-                    && await input?.confirm({
-                        message: `Directory ${destination} is not empty. Do you want to clear it?`,
+            } else if (!await fileSystem.isDirectory(destination)) {
+                if (
+                    await input?.confirm({
+                        message: `Destination ${destination} is not a directory. Do you want to delete it?`,
                         default: false,
                     }) !== true
                 ) {
-                    throw new ActionError('Destination directory is not empty.', {
+                    throw new ActionError('Destination is not a directory.', {
                         reason: ErrorReason.PRECONDITION,
-                        details: [`Directory: ${destination}`],
-                        suggestions: ['Clear the directory'],
+                        details: [`Path: ${destination}`],
+                        suggestions: ['Delete the file'],
                     });
                 }
-
-                await fileSystem.delete(destination, {recursive: true});
+            } else if (
+                !overwrite
+                && !await fileSystem.isEmptyDirectory(destination)
+                && await input?.confirm({
+                    message: `Directory ${destination} is not empty. Do you want to clear it?`,
+                    default: false,
+                }) !== true
+            ) {
+                throw new ActionError('Destination directory is not empty.', {
+                    reason: ErrorReason.PRECONDITION,
+                    details: [`Directory: ${destination}`],
+                    suggestions: ['Clear the directory'],
+                });
             }
+
+            await fileSystem.delete(destination, {recursive: true});
         }
 
-        await fileSystem.createDirectory(destination, {
+        return fileSystem.createDirectory(destination, {
             recursive: true,
         });
     }

--- a/src/infrastructure/application/validation/actions/downloadOptionsValidator.ts
+++ b/src/infrastructure/application/validation/actions/downloadOptionsValidator.ts
@@ -8,6 +8,7 @@ const schema: ZodType<DownloadOptions> = z.strictObject({
         .min(1)
         .optional(),
     destination: z.string().min(1),
+    overwrite: z.boolean(),
     result: z.strictObject({
         destination: z.string()
             .min(1)


### PR DESCRIPTION
## Summary

This PR adds support for overriding existing files during download. This is useful in scenarios where overwriting is intentional, such as scaffolding a new project from a template and replacing the default initial page

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings