### PR TITLE
Allow dash in option names

### DIFF
--- a/src/infrastructure/application/validation/templateValidator.ts
+++ b/src/infrastructure/application/validation/templateValidator.ts
@@ -47,7 +47,7 @@ const optionSchema: ZodType<OptionDefinition> = z.discriminatedUnion('type', [
 ]);
 
 const optionName = z.string()
-    .regex(/^[a-zA-Z0-9_-]+$/)
+    .regex(/^[a-zA-Z0-9][a-zA-Z0-9_-]*$/)
     .min(1);
 
 const templateSchema: ZodType<Template> = z.strictObject({

--- a/src/infrastructure/application/validation/templateValidator.ts
+++ b/src/infrastructure/application/validation/templateValidator.ts
@@ -47,7 +47,7 @@ const optionSchema: ZodType<OptionDefinition> = z.discriminatedUnion('type', [
 ]);
 
 const optionName = z.string()
-    .regex(/^[a-zA-Z0-9_]+$/)
+    .regex(/^[a-zA-Z0-9_-]+$/)
     .min(1);
 
 const templateSchema: ZodType<Template> = z.strictObject({


### PR DESCRIPTION
## Summary
This PR allows hyphens in option names, as long as they are not at the beginning.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings