### PR TITLE
Add support for overwriting files

### DIFF
--- a/src/application/template/action/downloadAction.ts
+++ b/src/application/template/action/downloadAction.ts
@@ -127,56 +127,61 @@ export class DownloadAction implements Action<DownloadOptions> {
     ): Promise<void> {
         const {fileSystem} = this.config;
 
-        if (await fileSystem.exists(destination)) {
-            if (entries.length === 1 && entries[0].type === 'file') {
-                if (
-                    !overwrite
-                    && await fileSystem.exists(entries[0].name)
-                    && await input?.confirm({
-                        message: `File ${entries[0].name} already exists. Do you want to overwrite it?`,
-                        default: false,
-                    }) !== true
-                ) {
-                    throw new ActionError('Destination file already exists.', {
-                        reason: ErrorReason.PRECONDITION,
-                        details: [`File: ${entries[0].name}`],
-                        suggestions: ['Delete the file'],
-                    });
-                }
-            } else {
-                if (!await fileSystem.isDirectory(destination)) {
-                    if (
-                        await input?.confirm({
-                            message: `Destination ${destination} is not a directory. Do you want to delete it?`,
-                            default: false,
-                        }) !== true
-                    ) {
-                        throw new ActionError('Destination is not a directory.', {
-                            reason: ErrorReason.PRECONDITION,
-                            details: [`Path: ${destination}`],
-                            suggestions: ['Delete the file'],
-                        });
-                    }
-                } else if (
-                    !overwrite
-                    && !await fileSystem.isEmptyDirectory(destination)
-                    && await input?.confirm({
-                        message: `Directory ${destination} is not empty. Do you want to clear it?`,
-                        default: false,
-                    }) !== true
-                ) {
-                    throw new ActionError('Destination directory is not empty.', {
-                        reason: ErrorReason.PRECONDITION,
-                        details: [`Directory: ${destination}`],
-                        suggestions: ['Clear the directory'],
-                    });
-                }
-
-                await fileSystem.delete(destination, {recursive: true});
-            }
+        if (!await fileSystem.exists(destination)) {
+            return fileSystem.createDirectory(destination, {
+                recursive: true,
+            });
         }
 
-        return fileSystem.createDirectory(destination, {
+        if (entries.length === 1 && entries[0].type === 'file' && await fileSystem.exists(entries[0].name)) {
+            if (
+                !overwrite
+                && await input?.confirm({
+                    message: `File ${entries[0].name} already exists. Do you want to overwrite it?`,
+                    default: false,
+                }) !== true
+            ) {
+                throw new ActionError('Destination file already exists.', {
+                    reason: ErrorReason.PRECONDITION,
+                    details: [`File: ${entries[0].name}`],
+                    suggestions: ['Delete the file'],
+                });
+            }
+
+            return;
+        }
+
+        if (!await fileSystem.isDirectory(destination)) {
+            if (
+                await input?.confirm({
+                    message: `Destination ${destination} is not a directory. Do you want to delete it?`,
+                    default: false,
+                }) !== true
+            ) {
+                throw new ActionError('Destination is not a directory.', {
+                    reason: ErrorReason.PRECONDITION,
+                    details: [`Path: ${destination}`],
+                    suggestions: ['Delete the file'],
+                });
+            }
+        } else if (
+            !overwrite
+            && !await fileSystem.isEmptyDirectory(destination)
+            && await input?.confirm({
+                message: `Directory ${destination} is not empty. Do you want to clear it?`,
+                default: false,
+            }) !== true
+        ) {
+            throw new ActionError('Destination directory is not empty.', {
+                reason: ErrorReason.PRECONDITION,
+                details: [`Directory: ${destination}`],
+                suggestions: ['Clear the directory'],
+            });
+        }
+
+        await fileSystem.delete(destination, {recursive: true});
+
+        await fileSystem.createDirectory(destination, {
             recursive: true,
         });
     }

--- a/src/application/template/action/downloadAction.ts
+++ b/src/application/template/action/downloadAction.ts
@@ -148,6 +148,8 @@ export class DownloadAction implements Action<DownloadOptions> {
                 });
             }
 
+            // No need to delete the file as it will be overwritten
+
             return;
         }
 


### PR DESCRIPTION
## Summary
This PR adds support for explicitly specifying when files should be overwritten during downloads. Previously, overwriting was disallowed by default to avoid accidental overwriting. However, there is a legitimate scenario for intentional overwriting, such as when initializing a new project where prompting the user isn't necessary.

By default, users will be prompted to confirm overwriting existing files, but this behavior can now be controlled using the overwrite flag. The only exception remains when the destination path exists as a file rather than a folder; in this case, the user will always be prompted, since the existing file must be deleted to create the required folder structure.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings