### PR TITLE
Set omitted options to null

### DIFF
--- a/src/application/template/action/importAction.ts
+++ b/src/application/template/action/importAction.ts
@@ -94,7 +94,10 @@ export class ImportAction implements Action<ImportOptions> {
 
             const resolvedValue = await (value ?? definition.resolveDefault?.(this.config.variables));
 
-            if (resolvedValue !== undefined) {
+            if (resolvedValue === undefined) {
+                // Set omitted options to null
+                values[name] = null;
+            } else {
                 if (definition.type === 'reference') {
                     ImportAction.checkOptionValue<'string'>(name, resolvedValue, {
                         ...definition,


### PR DESCRIPTION
## Summary

This PR sets `null` as the default value for optional options that are not specified. Previously, these values were `undefined`, which could lead to runtime errors when accessing properties like `options.flag`.

As a result, developers had to write verbose expressions such as `options.flag ?? null === null ? "value" : options.flag`, which hurts the developer experience.

With this change, all non-mandatory options default to `null` when not provided, making it easier to check for missing values using simple expressions like `options.flag === null`.

Since all valid option values are non-null by design, this change introduces no ambiguity.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings