### PR TITLE
Redesign project path resolution

### DIFF
--- a/src/application/project/configuration/projectConfiguration.ts
+++ b/src/application/project/configuration/projectConfiguration.ts
@@ -1,5 +1,13 @@
 import {ErrorReason, Help, HelpfulError} from '@/application/error';
 
+export type ProjectPaths = {
+    source: string,
+    utilities: string,
+    components: string,
+    examples: string,
+    content?: string,
+};
+
 export type ProjectConfiguration = {
     organization: string,
     workspace: string,
@@ -11,11 +19,7 @@ export type ProjectConfiguration = {
     locales: string[],
     slots: Record<string, string>,
     components: Record<string, string>,
-    paths: {
-        components: string,
-        examples: string,
-        content?: string,
-    },
+    paths?: Partial<ProjectPaths>,
 };
 
 export class ProjectConfigurationError extends HelpfulError {

--- a/src/application/project/sdk/javasScriptSdk.ts
+++ b/src/application/project/sdk/javasScriptSdk.ts
@@ -228,9 +228,9 @@ export abstract class JavaScriptSdk implements Sdk {
                 [
                     this.fileSystem.joinPaths('src', 'lib', 'utils'),
                     this.fileSystem.joinPaths('src', 'utils'),
+                    this.fileSystem.joinPaths('src', 'lib'),
                     this.fileSystem.joinPaths('lib', 'utils'),
                     'utils',
-                    this.fileSystem.joinPaths('src', 'lib'),
                     'lib',
                 ],
                 configuration.paths?.utilities,

--- a/src/application/project/sdk/lazySdk.ts
+++ b/src/application/project/sdk/lazySdk.ts
@@ -1,6 +1,6 @@
 import {Installation, Sdk, SdkError, UpdateOptions} from '@/application/project/sdk/sdk';
 import {Provider, ProviderError} from '@/application/provider/provider';
-import {ProjectConfiguration} from '@/application/project/configuration/projectConfiguration';
+import {ProjectConfiguration, ProjectPaths} from '@/application/project/configuration/projectConfiguration';
 import {Slot} from '@/application/model/slot';
 
 export class LazySdk implements Sdk {
@@ -22,6 +22,10 @@ export class LazySdk implements Sdk {
 
     public async setup(installation: Installation): Promise<ProjectConfiguration> {
         return (await this.sdk).setup(installation);
+    }
+
+    public async getPaths(configuration: ProjectConfiguration): Promise<ProjectPaths> {
+        return (await this.sdk).getPaths(configuration);
     }
 
     public async update(installation: Installation, options?: UpdateOptions): Promise<void> {

--- a/src/application/project/sdk/plugJsSdk.ts
+++ b/src/application/project/sdk/plugJsSdk.ts
@@ -44,10 +44,8 @@ export class PlugJsSdk extends JavaScriptSdk {
             });
         }
 
-        const directory = this.fileSystem.joinPaths(
-            installation.configuration.paths.examples,
-            slot.slug,
-        );
+        const paths = await this.getPaths(configuration);
+        const directory = this.fileSystem.joinPaths(paths.examples, slot.slug);
 
         const generator = new PlugJsExampleGenerator({
             fileSystem: this.fileSystem,

--- a/src/application/project/sdk/plugNextSdk.ts
+++ b/src/application/project/sdk/plugNextSdk.ts
@@ -100,15 +100,9 @@ export class PlugNextSdk extends JavaScriptSdk {
 
         const isTypeScript = await this.isTypeScriptProject();
 
-        const slotPath = this.fileSystem.joinPaths(
-            installation.configuration.paths.components,
-            `%slug%${isTypeScript ? '.tsx' : '.jsx'}`,
-        );
-
-        const pagePath = this.fileSystem.joinPaths(
-            installation.configuration.paths.examples,
-            '%slug%',
-        );
+        const paths = await this.getPaths(installation.configuration);
+        const slotPath = this.fileSystem.joinPaths(paths.components, `%slug%${isTypeScript ? '.tsx' : '.jsx'}`);
+        const pagePath = this.fileSystem.joinPaths(paths.examples, '%slug%');
 
         const slotImportPath = await this.importResolver.getImportPath(slotPath, pagePath);
 

--- a/src/application/project/sdk/plugReactSdk.ts
+++ b/src/application/project/sdk/plugReactSdk.ts
@@ -71,15 +71,9 @@ export class PlugReactSdk extends JavaScriptSdk {
     protected async generateSlotExampleFiles(slot: Slot, installation: Installation): Promise<ExampleFile[]> {
         const isTypeScript = await this.isTypeScriptProject();
 
-        const slotPath = this.fileSystem.joinPaths(
-            installation.configuration.paths.components,
-            `%slug%${isTypeScript ? '.tsx' : '.jsx'}`,
-        );
-
-        const pagePath = this.fileSystem.joinPaths(
-            installation.configuration.paths.examples,
-            `%slug%-example${isTypeScript ? '.tsx' : '.jsx'}`,
-        );
+        const paths = await this.getPaths(installation.configuration);
+        const slotPath = this.fileSystem.joinPaths(paths.components, `%slug%${isTypeScript ? '.tsx' : '.jsx'}`);
+        const pagePath = this.fileSystem.joinPaths(paths.examples, `%slug%-example${isTypeScript ? '.tsx' : '.jsx'}`);
 
         const generator = new PlugReactExampleGenerator({
             fileSystem: this.fileSystem,

--- a/src/application/project/sdk/sdk.ts
+++ b/src/application/project/sdk/sdk.ts
@@ -1,6 +1,6 @@
 import {Input} from '@/application/cli/io/input';
 import {Output} from '@/application/cli/io/output';
-import {ProjectConfiguration} from '@/application/project/configuration/projectConfiguration';
+import {ProjectConfiguration, ProjectPaths} from '@/application/project/configuration/projectConfiguration';
 import {Slot} from '@/application/model/slot';
 import {Help, HelpfulError} from '@/application/error';
 
@@ -23,6 +23,15 @@ export interface Sdk {
      * @throws SdkError If an error occurs.
      */
     setup(installation: Installation): Promise<ProjectConfiguration>;
+
+    /**
+     * Locates the project paths.
+     *
+     * @param configuration The project configuration.
+     *
+     * @returns The project paths.
+     */
+    getPaths(configuration: ProjectConfiguration): Promise<ProjectPaths>;
 
     /**
      * Update the SDK artifacts in the project.

--- a/src/infrastructure/application/cli/cli.ts
+++ b/src/infrastructure/application/cli/cli.ts
@@ -73,7 +73,7 @@ import {
 } from '@/application/cli/authentication/authenticator/multiAuthenticator';
 import {ApiError} from '@/application/api/error';
 import {UpgradeCommand, UpgradeInput} from '@/application/cli/command/upgrade';
-import {ProjectConfigurationError} from '@/application/project/configuration/projectConfiguration';
+import {ProjectConfigurationError, ProjectPaths} from '@/application/project/configuration/projectConfiguration';
 import {FileSystem, FileSystemIterator} from '@/application/fs/fileSystem';
 import {LocalFilesystem} from '@/application/fs/localFilesystem';
 import {FocusListener} from '@/infrastructure/application/cli/io/focusListener';
@@ -1277,14 +1277,12 @@ export class Cli {
                         };
                     },
                 ),
-                path: {
-                    example: LazyPromise.transient(
-                        async () => (await this.getConfigurationManager().load()).paths.examples,
-                    ),
-                    component: LazyPromise.transient(
-                        async () => (await this.getConfigurationManager().load()).paths.components,
-                    ),
-                },
+                path: LazyPromise.transient(async (): Promise<ProjectPaths> => {
+                    const sdk = this.getSdk();
+                    const configuration = await this.getConfigurationManager().load();
+
+                    return sdk.getPaths(configuration);
+                }),
                 platform: LazyPromise.transient(async () => (await this.getPlatformProvider().get()) ?? 'unknown'),
                 server: LazyPromise.transient(async (): Promise<{running: boolean, url?: string}|null> => {
                     const serverProvider = this.getServerProvider();

--- a/src/infrastructure/application/validation/croctConfigurationValidator.ts
+++ b/src/infrastructure/application/validation/croctConfigurationValidator.ts
@@ -1,4 +1,4 @@
-import {z} from 'zod';
+import {z, ZodTypeDef} from 'zod';
 import {ZodValidator} from '@/infrastructure/application/validation/zodValidator';
 import {Version} from '@/application/model/version';
 import {ProjectConfiguration} from '@/application/project/configuration/projectConfiguration';
@@ -32,7 +32,7 @@ const versionSchema = z.string()
 type PartialProjectConfiguration = Omit<ProjectConfiguration, 'slots' | 'components'>
     & Partial<Pick<ProjectConfiguration, 'slots' | 'components'>>;
 
-const configurationSchema = z.strictObject({
+const configurationSchema: z.ZodType<ProjectConfiguration, ZodTypeDef, PartialProjectConfiguration> = z.strictObject({
     $schema: z.string().optional(),
     organization: identifierSchema,
     workspace: identifierSchema,

--- a/src/infrastructure/application/validation/croctConfigurationValidator.ts
+++ b/src/infrastructure/application/validation/croctConfigurationValidator.ts
@@ -52,7 +52,7 @@ const configurationSchema = z.strictObject({
         components: z.string().optional(),
         examples: z.string().optional(),
         content: z.string().optional(),
-    }),
+    }).optional(),
 }).refine(data => data.locales.includes(data.defaultLocale), {
     message: 'The default locale is not included in the list of locales.',
     path: ['defaultLocale'],

--- a/src/infrastructure/application/validation/croctConfigurationValidator.ts
+++ b/src/infrastructure/application/validation/croctConfigurationValidator.ts
@@ -1,4 +1,4 @@
-import {z, ZodTypeDef} from 'zod';
+import {z} from 'zod';
 import {ZodValidator} from '@/infrastructure/application/validation/zodValidator';
 import {Version} from '@/application/model/version';
 import {ProjectConfiguration} from '@/application/project/configuration/projectConfiguration';
@@ -32,7 +32,7 @@ const versionSchema = z.string()
 type PartialProjectConfiguration = Omit<ProjectConfiguration, 'slots' | 'components'>
     & Partial<Pick<ProjectConfiguration, 'slots' | 'components'>>;
 
-const configurationSchema: z.ZodType<ProjectConfiguration, ZodTypeDef, PartialProjectConfiguration> = z.strictObject({
+const configurationSchema = z.strictObject({
     $schema: z.string().optional(),
     organization: identifierSchema,
     workspace: identifierSchema,
@@ -47,8 +47,10 @@ const configurationSchema: z.ZodType<ProjectConfiguration, ZodTypeDef, PartialPr
     components: z.record(versionSchema)
         .default({}),
     paths: z.strictObject({
-        components: z.string(),
-        examples: z.string(),
+        source: z.string().optional(),
+        utilities: z.string().optional(),
+        components: z.string().optional(),
+        examples: z.string().optional(),
         content: z.string().optional(),
     }),
 }).refine(data => data.locales.includes(data.defaultLocale), {

--- a/src/infrastructure/application/validation/zodValidator.ts
+++ b/src/infrastructure/application/validation/zodValidator.ts
@@ -1,10 +1,10 @@
 import {ZodType, ZodTypeDef} from 'zod';
 import {Validator, ValidationResult, Violation} from '@/application/validation';
 
-export class ZodValidator<O, I = O> implements Validator<O> {
-    protected readonly schema: ZodType<O, ZodTypeDef, I>;
+export class ZodValidator<O, I = O, D extends ZodTypeDef = ZodTypeDef> implements Validator<O> {
+    protected readonly schema: ZodType<O, D, I>;
 
-    public constructor(schema: ZodType<O, ZodTypeDef, I>) {
+    public constructor(schema: ZodType<O, D, I>) {
         this.schema = schema;
     }
 


### PR DESCRIPTION
## Summary

While working on templates, I realized the need for additional configurable paths, such as paths for libraries and source files (e.g., `src`), which are currently not supported in the config file. The issue is that paths are resolved only once during initialization, so introducing new paths later would be a breaking change. At that point, the CLI would either reject the configuration and force re-initialization or assume a default path without verifying the folder exists.

To address this, this PR refactors the path resolution logic to allow all paths in the config file to be optional. It also introduces a new `getPaths` method in the SDK, which encapsulates the logic for resolving folder paths—even after the initial setup.

With this change, projects are no longer required to specify all paths up front. The CLI can now resolve them dynamically at runtime, enabling graceful evolution as new path types are introduced.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings