### PR TITLE
Fix path resolution logic

### DIFF
--- a/src/application/project/sdk/javasScriptSdk.ts
+++ b/src/application/project/sdk/javasScriptSdk.ts
@@ -273,7 +273,7 @@ export abstract class JavaScriptSdk implements Sdk {
             return path;
         }
 
-        return paths[0] ?? defaultPath;
+        return defaultPath;
     }
 
     protected abstract getInstallationPlan(installation: Installation): Promise<InstallationPlan>;


### PR DESCRIPTION
## Summary
The current resolution logic is always using the first path of the list instead of the default path specified.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings