### PR TITLE
Remove default paths and slots

### DIFF
--- a/src/application/cli/command/init.ts
+++ b/src/application/cli/command/init.ts
@@ -18,6 +18,8 @@ import {Application, ApplicationEnvironment} from '@/application/model/applicati
 import {ErrorReason, HelpfulError} from '@/application/error';
 import {Platform} from '@/application/model/platform';
 import {Provider} from '@/application/provider/provider';
+import {Slot} from '@/application/model/slot';
+import {SlotOptions} from '@/application/cli/form/workspace/slotForm';
 
 export type Resource = 'organization' | 'workspace' | 'application';
 
@@ -40,6 +42,7 @@ export type InitConfig = {
         organization: Form<Organization, OrganizationOptions>,
         workspace: Form<Workspace, WorkspaceOptions>,
         application: Form<Application, ApplicationOptions>,
+        slot: Form<Slot[], SlotOptions>,
     },
     api: {
         user: UserApi,
@@ -246,13 +249,38 @@ export class InitCommand implements Command<InitInput> {
 
     private async configure(sdk: Sdk, configuration: ProjectConfiguration): Promise<ProjectConfiguration> {
         const {skipConfirmation} = this.config;
+        const slots = await this.getSlots(configuration.organization, configuration.workspace);
 
         return sdk.setup({
             input: this.config.io.input === undefined || await skipConfirmation.get()
                 ? undefined
                 : this.config.io.input,
             output: this.config.io.output,
-            configuration: configuration,
+            configuration: Object.keys(slots).length === 0
+                ? configuration
+                : {
+                    ...configuration,
+                    slots: slots,
+                },
         });
+    }
+
+    private async getSlots(organizationSlug: string, workspaceSlug: string): Promise<Record<string, string>> {
+        const {io: {input}, form} = this.config;
+
+        if (input === undefined) {
+            return {};
+        }
+
+        const slots = await form.slot.handle({
+            organizationSlug: organizationSlug,
+            workspaceSlug: workspaceSlug,
+            selectionConfirmation: {
+                message: 'Do you want to add slots to your project?',
+                default: false,
+            },
+        });
+
+        return Object.fromEntries(slots.map(slot => [slot.slug, `${slot.version.major}`]));
     }
 }

--- a/src/infrastructure/application/cli/cli.ts
+++ b/src/infrastructure/application/cli/cli.ts
@@ -497,6 +497,11 @@ export class Cli {
                         output: this.getOutput(),
                         workspaceApi: this.getWorkspaceApi(),
                     }),
+                    slot: new SlotForm({
+                        input: this.getFormInput(),
+                        output: this.getOutput(),
+                        workspaceApi: this.getWorkspaceApi(),
+                    }),
                 },
                 io: {
                     input: this.getInput(),


### PR DESCRIPTION
## Summary
After #31, there's no need to specify default paths during initialization or when no suitable SDK is identified, as this can now be resolved at runtime the next time the CLI is executed.

Currently, the CLI adds all slots from the workspace to the project by default. However, projects can contain hundreds of slots, while only a few may actually be used. This slows things down, as the CLI has to install each slot, download their content, generate types, and so on.

This PR changes that behavior by prompting developers at the end of the process to choose whether they want to add any slots. This way, they can select only the ones they actually need.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings