### PR TITLE
Add auto-update for deep links

### DIFF
--- a/src/application/cli/command/open.ts
+++ b/src/application/cli/command/open.ts
@@ -1,6 +1,6 @@
 import {Command} from '@/application/cli/command/command';
 import {ErrorReason, HelpfulError} from '@/application/error';
-import {CliConfiguration} from '@/application/cli/configuration/store';
+import {CliConfiguration} from '@/application/cli/configuration/provider';
 import {CurrentWorkingDirectory} from '@/application/fs/workingDirectory/workingDirectory';
 import {Provider} from '@/application/provider/provider';
 import {Input} from '@/application/cli/io/input';

--- a/src/application/cli/command/welcome.ts
+++ b/src/application/cli/command/welcome.ts
@@ -5,6 +5,7 @@ import {Output} from '@/application/cli/io/output';
 import {Provider} from '@/application/provider/provider';
 import {PackageManager} from '@/application/project/packageManager/packageManager';
 import {CliConfigurationProvider} from '@/application/cli/configuration/provider';
+import {HelpfulError} from '@/application/error';
 
 export type WelcomeInput = Record<string, never>;
 
@@ -29,7 +30,13 @@ export class WelcomeCommand implements Command<WelcomeInput> {
     }
 
     public async execute(): Promise<void> {
-        await this.enableDeepLinks();
+        const {output} = this.config.io;
+
+        try {
+            await this.enableDeepLinks();
+        } catch (error) {
+            output.alert(`Failed to enable deep links: ${HelpfulError.formatCause(error)}`);
+        }
     }
 
     private async enableDeepLinks(): Promise<void> {

--- a/src/application/cli/command/welcome.ts
+++ b/src/application/cli/command/welcome.ts
@@ -103,7 +103,7 @@ export class WelcomeCommand implements Command<WelcomeInput> {
         const notifier = output.notify('Enabling deep links...');
 
         try {
-            await this.enableDeepLinks();
+            await this.installDeepLinks(registry);
 
             output.confirm('Deep links enabled');
         } finally {

--- a/src/application/cli/command/welcome.ts
+++ b/src/application/cli/command/welcome.ts
@@ -49,6 +49,16 @@ export class WelcomeCommand implements Command<WelcomeInput> {
             io: {output, input},
         } = this.config;
 
+        const configuration = await configurationProvider.get();
+        const installedVersion = configuration.version;
+
+        if (installedVersion !== version) {
+            await configurationProvider.save({
+                ...configuration,
+                version: version,
+            });
+        }
+
         const registry = await protocolRegistryProvider.get();
 
         if (registry === null || input === undefined) {
@@ -65,9 +75,7 @@ export class WelcomeCommand implements Command<WelcomeInput> {
         }
 
         if (isRegistered) {
-            const configuration = await configurationProvider.get();
-
-            if (configuration.version !== version) {
+            if (installedVersion !== version) {
                 // The CLI has been updated, re-register the protocol handler to ensure
                 // any changes are applied
                 await registry.unregister(protocolHandler.protocol);
@@ -81,11 +89,6 @@ export class WelcomeCommand implements Command<WelcomeInput> {
                 } finally {
                     notifier.stop();
                 }
-
-                await configurationProvider.save({
-                    ...configuration,
-                    version: version,
-                });
             }
 
             return;

--- a/src/application/cli/configuration/fileConfigurationStore.ts
+++ b/src/application/cli/configuration/fileConfigurationStore.ts
@@ -1,6 +1,6 @@
 import {FileSystem} from '@/application/fs/fileSystem';
 import {Validator} from '@/application/validation';
-import {CliConfiguration, CliConfigurationProvider} from '@/application/cli/configuration/store';
+import {CliConfiguration, CliConfigurationProvider} from '@/application/cli/configuration/provider';
 
 export type Configuration = {
     fileSystem: FileSystem,

--- a/src/application/cli/configuration/normalizedConfigurationStore.ts
+++ b/src/application/cli/configuration/normalizedConfigurationStore.ts
@@ -1,34 +1,34 @@
 import {FileSystem} from '@/application/fs/fileSystem';
-import {CliConfiguration, CliConfigurationProvider} from '@/application/cli/configuration/store';
+import {CliConfiguration, CliConfigurationProvider} from '@/application/cli/configuration/provider';
 
 export type Configuration = {
     fileSystem: FileSystem,
-    store: CliConfigurationProvider,
+    configurationProvider: CliConfigurationProvider,
 };
 
 export class NormalizedConfigurationStore implements CliConfigurationProvider {
     private readonly fileSystem: FileSystem;
 
-    private readonly store: CliConfigurationProvider;
+    private readonly configurationProvider: CliConfigurationProvider;
 
-    public constructor({fileSystem, store}: Configuration) {
+    public constructor({fileSystem, configurationProvider}: Configuration) {
         this.fileSystem = fileSystem;
-        this.store = store;
+        this.configurationProvider = configurationProvider;
     }
 
     public async get(): Promise<CliConfiguration> {
-        return this.normalizeSettings(await this.store.get());
+        return this.normalizeSettings(await this.configurationProvider.get());
     }
 
     public async save(settings: CliConfiguration): Promise<void> {
-        return this.store.save(await this.normalizeSettings(settings));
+        return this.configurationProvider.save(await this.normalizeSettings(settings));
     }
 
-    private async normalizeSettings(settings: CliConfiguration): Promise<CliConfiguration> {
+    private async normalizeSettings(configuration: CliConfiguration): Promise<CliConfiguration> {
         return {
-            ...settings,
+            ...configuration,
             projectPaths: (await Promise.all(
-                [...new Set(settings.projectPaths)].map(
+                [...new Set(configuration.projectPaths)].map(
                     async path => (await this.fileSystem.exists(path) ? [path] : []),
                 ),
             )).flat(),

--- a/src/application/cli/configuration/provider.ts
+++ b/src/application/cli/configuration/provider.ts
@@ -2,6 +2,7 @@ import {Provider} from '@/application/provider/provider';
 
 export type CliConfiguration = {
     projectPaths: string[],
+    version?: string,
     isDeepLinkingEnabled?: boolean,
 };
 

--- a/src/application/project/configuration/manager/indexedConfigurationManager.ts
+++ b/src/application/project/configuration/manager/indexedConfigurationManager.ts
@@ -1,25 +1,25 @@
 import {ProjectConfiguration} from '@/application/project/configuration/projectConfiguration';
 import {ConfigurationManager} from '@/application/project/configuration/manager/configurationManager';
 import {WorkingDirectory} from '@/application/fs/workingDirectory/workingDirectory';
-import {CliConfigurationProvider} from '@/application/cli/configuration/store';
+import {CliConfigurationProvider} from '@/application/cli/configuration/provider';
 
 export type Configuration = {
     manager: ConfigurationManager,
-    store: CliConfigurationProvider,
+    configurationProvider: CliConfigurationProvider,
     workingDirectory: WorkingDirectory,
 };
 
 export class IndexedConfigurationManager implements ConfigurationManager {
     private readonly manager: ConfigurationManager;
 
-    private readonly store: CliConfigurationProvider;
+    private readonly configurationProvider: CliConfigurationProvider;
 
     private readonly workingDirectory: WorkingDirectory;
 
-    public constructor({manager, workingDirectory, store}: Configuration) {
+    public constructor({manager, workingDirectory, configurationProvider}: Configuration) {
         this.manager = manager;
         this.workingDirectory = workingDirectory;
-        this.store = store;
+        this.configurationProvider = configurationProvider;
     }
 
     public isInitialized(): Promise<boolean> {
@@ -40,11 +40,11 @@ export class IndexedConfigurationManager implements ConfigurationManager {
     }
 
     private async updateIndex(): Promise<void> {
-        const settings = await this.store.get();
+        const configuration = await this.configurationProvider.get();
 
-        await this.store.save({
-            ...settings,
-            projectPaths: [this.workingDirectory.get(), ...settings.projectPaths],
+        await this.configurationProvider.save({
+            ...configuration,
+            projectPaths: [this.workingDirectory.get(), ...configuration.projectPaths],
         });
     }
 }

--- a/src/application/project/packageManager/agent/executableAgent.ts
+++ b/src/application/project/packageManager/agent/executableAgent.ts
@@ -68,7 +68,7 @@ export abstract class ExecutableAgent implements PackageManagerAgent {
             throw new PackageManagerError(`Package manager \`${this.getCommandName()}\` is not installed.`);
         }
 
-        const execution = this.commandRunner.run(command, {
+        const execution = await this.commandRunner.run(command, {
             ...options,
             workingDirectory: this.projectDirectory.get(),
         });

--- a/src/application/project/server/processServer.ts
+++ b/src/application/project/server/processServer.ts
@@ -48,7 +48,7 @@ export class ProcessServer implements Server {
         const {commandExecutor, command, workingDirectory, processObserver} = this.configuration;
 
         try {
-            this.execution = commandExecutor.run(command, {
+            this.execution = await commandExecutor.run(command, {
                 workingDirectory: workingDirectory.get(),
             });
         } catch (error) {

--- a/src/application/system/executableLocator.ts
+++ b/src/application/system/executableLocator.ts
@@ -30,7 +30,7 @@ export class ExecutableLocator {
 
     private async findPath(command: string): Promise<string|null> {
         for (const path of this.executablePaths) {
-            for (const extension of ['', ...this.executableExtensions]) {
+            for (const extension of [...this.executableExtensions, '']) {
                 const realPath = this.fileSystem.joinPaths(path, command + extension.toLowerCase());
 
                 if (realPath !== null && await this.fileSystem.exists(realPath)) {

--- a/src/application/system/process/executor.ts
+++ b/src/application/system/process/executor.ts
@@ -37,7 +37,7 @@ export type ExecutionOptions = {
 };
 
 export interface CommandExecutor {
-    run(command: Command, options?: ExecutionOptions): Execution;
+    run(command: Command, options?: ExecutionOptions): Promise<Execution>;
 }
 
 export interface SynchronousCommandExecutor {

--- a/src/application/system/protocol/linuxRegistry.ts
+++ b/src/application/system/protocol/linuxRegistry.ts
@@ -127,7 +127,7 @@ export class LinuxRegistry implements ProtocolRegistry {
     }
 
     private async execute(command: Command): Promise<string> {
-        const execution = this.commandExecutor.run(command);
+        const execution = await this.commandExecutor.run(command);
 
         if (await execution.wait() !== 0) {
             throw new HelpfulError(`Failed to execute command \`${command.name}\`.`);

--- a/src/application/system/protocol/macOsRegistry.ts
+++ b/src/application/system/protocol/macOsRegistry.ts
@@ -154,6 +154,8 @@ export class MacOsRegistry implements ProtocolRegistry {
         const execution = this.commandExecutor.run(command);
 
         if (await execution.wait() !== 0) {
+            console.log(await execution.read());
+
             throw new HelpfulError(`Failed to execute command \`${command.name}\`.`);
         }
 

--- a/src/application/system/protocol/macOsRegistry.ts
+++ b/src/application/system/protocol/macOsRegistry.ts
@@ -154,8 +154,6 @@ export class MacOsRegistry implements ProtocolRegistry {
         const execution = this.commandExecutor.run(command);
 
         if (await execution.wait() !== 0) {
-            console.log(await execution.read());
-
             throw new HelpfulError(`Failed to execute command \`${command.name}\`.`);
         }
 

--- a/src/application/system/protocol/macOsRegistry.ts
+++ b/src/application/system/protocol/macOsRegistry.ts
@@ -151,7 +151,7 @@ export class MacOsRegistry implements ProtocolRegistry {
     }
 
     private async execute(command: Command): Promise<string> {
-        const execution = this.commandExecutor.run(command);
+        const execution = await this.commandExecutor.run(command);
 
         if (await execution.wait() !== 0) {
             throw new HelpfulError(`Failed to execute command \`${command.name}\`.`);

--- a/src/application/system/protocol/windowsRegistry.ts
+++ b/src/application/system/protocol/windowsRegistry.ts
@@ -87,7 +87,7 @@ export class WindowsRegistry implements ProtocolRegistry {
     }
 
     private async execute(command: Command): Promise<string> {
-        const execution = this.commandExecutor.run(command);
+        const execution = await this.commandExecutor.run(command);
 
         if (await execution.wait() !== 0) {
             throw new HelpfulError(`Failed to execute command \`${command.name}\`.`);

--- a/src/application/template/action/executePackage.ts
+++ b/src/application/template/action/executePackage.ts
@@ -110,7 +110,7 @@ export class ExecutePackage implements Action<ExecutePackageOptions> {
     private async executeCommand(command: Command, interactions: Interactions[] = []): Promise<void> {
         const {workingDirectory, commandExecutor, commandTimeout} = this.configuration;
 
-        const execution = commandExecutor.run(command, {
+        const execution = await commandExecutor.run(command, {
             workingDirectory: workingDirectory.get(),
             timeout: commandTimeout,
         });

--- a/src/infrastructure/application/cli/cli.ts
+++ b/src/infrastructure/application/cli/cli.ts
@@ -1913,6 +1913,9 @@ export class Cli {
             () => new SpawnExecutor({
                 currentDirectory: this.workingDirectory,
                 executableLocator: this.getExecutableLocator(),
+                windows: this.configuration
+                    .process
+                    .getPlatform() === 'win32',
             }),
         );
     }

--- a/src/infrastructure/application/cli/cli.ts
+++ b/src/infrastructure/application/cli/cli.ts
@@ -1906,10 +1906,8 @@ export class Cli {
         return this.share(
             this.getCommandExecutor,
             () => new SpawnExecutor({
-                // Windows require using shell to find executables
-                shell: this.configuration
-                    .process
-                    .getPlatform() === 'win32',
+                currentDirectory: this.workingDirectory,
+                executableLocator: this.getExecutableLocator(),
             }),
         );
     }

--- a/src/infrastructure/application/cli/program.ts
+++ b/src/infrastructure/application/cli/program.ts
@@ -386,6 +386,7 @@ export async function run(args: string[] = process.argv, welcome = true): Promis
 
     const cli = Cli.fromDefaults({
         program: params => run(invocation.args.slice(0, 2).concat(params)),
+        version: packageJson.version,
         quiet: options.quiet,
         debug: options.debug,
         interactive: options.interaction ? undefined : false,

--- a/src/infrastructure/application/project/javaScriptFormatter.ts
+++ b/src/infrastructure/application/project/javaScriptFormatter.ts
@@ -44,7 +44,7 @@ export class JavaScriptFormatter implements CodeFormatter {
     private async run(command: Command): Promise<void> {
         const {commandExecutor, workingDirectory, timeout} = this.configuration;
 
-        const execution = commandExecutor.run(command, {
+        const execution = await commandExecutor.run(command, {
             workingDirectory: workingDirectory.get(),
             timeout: timeout,
         });

--- a/src/infrastructure/application/system/command/spawnExecutor.ts
+++ b/src/infrastructure/application/system/command/spawnExecutor.ts
@@ -43,6 +43,10 @@ export class SpawnExecutor implements CommandExecutor, SynchronousCommandExecuto
 
         const subprocess = spawn(executable, command.arguments, {
             stdio: ['pipe', 'pipe', 'pipe'],
+            // Node does not allow to spawn .bat or .cmd files on Windows because
+            // arguments are not escaped:
+            // https://github.com/nodejs/node/commit/69ffc6d50dbd9d7d0257f5b9b403026e1aa205ee
+            shell: /\.(bat|cmd)$/i.test(executable),
             cwd: options?.workingDirectory ?? this.currentDirectory?.get(),
             signal: timeoutSignal,
         });

--- a/src/infrastructure/application/system/command/spawnExecutor.ts
+++ b/src/infrastructure/application/system/command/spawnExecutor.ts
@@ -41,12 +41,13 @@ export class SpawnExecutor implements CommandExecutor, SynchronousCommandExecuto
             throw new ExecutionError(`Unable to locate executable for command \`${command.name}\`.`);
         }
 
-        const subprocess = spawn(executable, command.arguments, {
+        const shell = /\.(bat|cmd)$/i.test(executable);
+        const subprocess = spawn(shell ? `"${executable}"` : executable, command.arguments, {
             stdio: ['pipe', 'pipe', 'pipe'],
             // Node does not allow to spawn .bat or .cmd files on Windows because
             // arguments are not escaped:
             // https://github.com/nodejs/node/commit/69ffc6d50dbd9d7d0257f5b9b403026e1aa205ee
-            shell: /\.(bat|cmd)$/i.test(executable),
+            shell: shell,
             cwd: options?.workingDirectory ?? this.currentDirectory?.get(),
             signal: timeoutSignal,
         });

--- a/src/infrastructure/application/system/command/spawnExecutor.ts
+++ b/src/infrastructure/application/system/command/spawnExecutor.ts
@@ -16,13 +16,17 @@ import {Command} from '@/application/system/process/command';
 
 export type Configuration = {
     currentDirectory?: WorkingDirectory,
+    shell?: boolean,
 };
 
 export class SpawnExecutor implements CommandExecutor, SynchronousCommandExecutor {
     private readonly currentDirectory?: WorkingDirectory;
 
-    public constructor({currentDirectory}: Configuration = {}) {
+    private readonly shell: boolean;
+
+    public constructor({currentDirectory, shell = false}: Configuration = {}) {
         this.currentDirectory = currentDirectory;
+        this.shell = shell;
     }
 
     public run(command: Command, options: ExecutionOptions = {}): Execution {
@@ -31,7 +35,7 @@ export class SpawnExecutor implements CommandExecutor, SynchronousCommandExecuto
             : undefined;
 
         const subprocess = spawn(command.name, command.arguments, {
-            shell: true,
+            shell: this.shell,
             stdio: ['pipe', 'pipe', 'pipe'],
             cwd: options?.workingDirectory ?? this.currentDirectory?.get(),
             signal: timeoutSignal,

--- a/src/infrastructure/application/system/command/spawnExecutor.ts
+++ b/src/infrastructure/application/system/command/spawnExecutor.ts
@@ -18,6 +18,7 @@ import {ExecutableLocator} from '@/application/system/executableLocator';
 export type Configuration = {
     currentDirectory?: WorkingDirectory,
     executableLocator: ExecutableLocator,
+    windows?: boolean,
 };
 
 export class SpawnExecutor implements CommandExecutor, SynchronousCommandExecutor {
@@ -25,9 +26,12 @@ export class SpawnExecutor implements CommandExecutor, SynchronousCommandExecuto
 
     private readonly executableLocator: ExecutableLocator;
 
-    public constructor({currentDirectory, executableLocator}: Configuration) {
+    private readonly isWindows: boolean;
+
+    public constructor({currentDirectory, executableLocator, windows = false}: Configuration) {
         this.currentDirectory = currentDirectory;
         this.executableLocator = executableLocator;
+        this.isWindows = windows;
     }
 
     public async run(command: Command, options: ExecutionOptions = {}): Promise<Execution> {
@@ -41,7 +45,7 @@ export class SpawnExecutor implements CommandExecutor, SynchronousCommandExecuto
             throw new ExecutionError(`Unable to locate executable for command \`${command.name}\`.`);
         }
 
-        const shell = /\.(bat|cmd)$/i.test(executable);
+        const shell = this.isWindows && /\.(bat|cmd)$/i.test(executable);
         const subprocess = spawn(shell ? `"${executable}"` : executable, command.arguments, {
             stdio: ['pipe', 'pipe', 'pipe'],
             // Node does not allow to spawn .bat or .cmd files on Windows because

--- a/src/infrastructure/application/validation/cliSettingsValidator.ts
+++ b/src/infrastructure/application/validation/cliSettingsValidator.ts
@@ -1,8 +1,9 @@
 import {z, ZodType} from 'zod';
 import {ZodValidator} from '@/infrastructure/application/validation/zodValidator';
-import {CliConfiguration} from '@/application/cli/configuration/store';
+import {CliConfiguration} from '@/application/cli/configuration/provider';
 
 const schema: ZodType<CliConfiguration> = z.strictObject({
+    version: z.string().optional(),
     projectPaths: z.array(z.string().min(1)),
     isDeepLinkingEnabled: z.boolean().optional(),
 });


### PR DESCRIPTION
## Summary
This PR adds a mechanism to detect when the CLI has been updated and automatically reinstalls deep links. This eliminates the need for manual intervention and prevents issues caused by outdated links after an update.

It also reverts the change from #22 that forced commands to run in shell mode—a workaround that introduced several problems, such as macOS failing to pass multiline arguments. That change was originally made to ensure commands like npm could be resolved on Windows, where global executables aren't always directly accessible.

To solve this properly, the command executor now resolves the full path of the executable by inspecting the system’s PATH and supported extensions. Since Node.js can't spawn .bat and .cmd files directly, those are still run in shell mode.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings