### PR TITLE
Restore version tracking

### DIFF
--- a/src/application/cli/command/welcome.ts
+++ b/src/application/cli/command/welcome.ts
@@ -21,12 +21,6 @@ export class WelcomeCommand implements Command<WelcomeInput> {
     }
 
     public async execute(input: WelcomeInput): Promise<void> {
-        if (input.skipDeepLinkCheck !== true) {
-            await this.setupDeepLinks();
-        }
-    }
-
-    private async setupDeepLinks(): Promise<void> {
         const {configurationProvider, version, deepLinkInstaller} = this.config;
 
         const configuration = await configurationProvider.get();
@@ -40,6 +34,8 @@ export class WelcomeCommand implements Command<WelcomeInput> {
             });
         }
 
-        await deepLinkInstaller(installedVersion !== version);
+        if (input.skipDeepLinkCheck !== true) {
+            await deepLinkInstaller(installedVersion !== version);
+        }
     }
 }


### PR DESCRIPTION
## Summary
This PR fixes a bug introduced in #35 where the CLI version was only being tracked when not running a deep-link command, whereas it should be tracked in all cases.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings