### PR TITLE
Add support for renaming downloaded files

### DIFF
--- a/src/application/cli/command/init.ts
+++ b/src/application/cli/command/init.ts
@@ -249,38 +249,13 @@ export class InitCommand implements Command<InitInput> {
 
     private async configure(sdk: Sdk, configuration: ProjectConfiguration): Promise<ProjectConfiguration> {
         const {skipConfirmation} = this.config;
-        const slots = await this.getSlots(configuration.organization, configuration.workspace);
 
         return sdk.setup({
             input: this.config.io.input === undefined || await skipConfirmation.get()
                 ? undefined
                 : this.config.io.input,
             output: this.config.io.output,
-            configuration: Object.keys(slots).length === 0
-                ? configuration
-                : {
-                    ...configuration,
-                    slots: slots,
-                },
+            configuration: configuration,
         });
-    }
-
-    private async getSlots(organizationSlug: string, workspaceSlug: string): Promise<Record<string, string>> {
-        const {io: {input}, form} = this.config;
-
-        if (input === undefined) {
-            return {};
-        }
-
-        const slots = await form.slot.handle({
-            organizationSlug: organizationSlug,
-            workspaceSlug: workspaceSlug,
-            selectionConfirmation: {
-                message: 'Do you want to add slots to your project?',
-                default: false,
-            },
-        });
-
-        return Object.fromEntries(slots.map(slot => [slot.slug, `${slot.version.major}`]));
     }
 }

--- a/src/infrastructure/application/validation/actions/downloadOptionsValidator.ts
+++ b/src/infrastructure/application/validation/actions/downloadOptionsValidator.ts
@@ -8,6 +8,7 @@ const schema: ZodType<DownloadOptions> = z.strictObject({
         .min(1)
         .optional(),
     destination: z.string().min(1),
+    mapping: z.record(z.string().min(1), z.string().min(1)).optional(),
     overwrite: z.boolean(),
     result: z.strictObject({
         destination: z.string()


### PR DESCRIPTION
## Summary
This PR introduces support for renaming downloaded files and directories by allowing a mapping of original paths to target paths.

Previously, the downloaded files had to match the target paths exactly. This limitation made it difficult to reuse the same source file under different names or extensions—especially when the file contents are the same but the desired output varies depending on the context.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings