### PR TITLE
Allow metadata in templates

### DIFF
--- a/src/infrastructure/application/evaluation/jsepExpressionEvaluator.ts
+++ b/src/infrastructure/application/evaluation/jsepExpressionEvaluator.ts
@@ -67,6 +67,8 @@ export class JsepExpressionEvaluator implements ExpressionEvaluator {
     private static readonly ALLOWED_ARRAY_METHODS: Array<Methods<any[]>> = [
         'slice',
         'join',
+        'includes',
+        'indexOf',
     ];
 
     // eslint-disable-next-line @typescript-eslint/ban-types -- Intentional use of String for correct type inference

--- a/src/infrastructure/application/validation/templateValidator.ts
+++ b/src/infrastructure/application/validation/templateValidator.ts
@@ -54,6 +54,7 @@ const templateSchema: ZodType<Template> = z.strictObject({
     $schema: z.string().optional(),
     title: z.string().min(1),
     description: z.string().min(1),
+    metadata: z.record(z.string(), jsonSchema).optional(),
     options: z.record(optionName, optionSchema).optional(),
     actions: z.array(z.any()),
 });


### PR DESCRIPTION
## Summary
Add metadata to the list of allowed properties in templates.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings