### PR TITLE
Fix deep links

### DIFF
--- a/src/application/system/protocol/macOsRegistry.ts
+++ b/src/application/system/protocol/macOsRegistry.ts
@@ -180,7 +180,7 @@ export class MacOsRegistry implements ProtocolRegistry {
         return multiline`
             set this_URL to do shell script "defaults read ${id} current_url"
             tell application "Terminal"
-              do shell script "${command}"
+              do script "${command}"
               activate
             end tell
         `;

--- a/src/infrastructure/application/cli/program.ts
+++ b/src/infrastructure/application/cli/program.ts
@@ -362,10 +362,10 @@ function createProgram(config: Configuration): typeof program {
         useCommand.addOption(option);
     }
 
-    const deepLink = program.command('deep-link')
-        .description('Enable or disable deep link support.');
+    const enable = program.command('enable')
+        .description('Enable a feature.');
 
-    deepLink.command('enable')
+    enable.command('deep-link')
         .description('Enable deep link support.')
         .action(async () => {
             await config.cli?.deepLink({
@@ -373,7 +373,10 @@ function createProgram(config: Configuration): typeof program {
             });
         });
 
-    deepLink.command('disable')
+    const disable = program.command('disable')
+        .description('Disable a feature.');
+
+    disable.command('deep-link')
         .description('Disable deep link support.')
         .action(async () => {
             await config.cli?.deepLink({
@@ -396,6 +399,10 @@ function getTemplate(args: string[]): string | null {
     }
 
     return null;
+}
+
+function isDeepLinkCommand(args: string[]): boolean {
+    return args.length >= 2 && ['enable', 'disable'].includes(args[0]) && args[1] === 'deep-link';
 }
 
 export async function run(args: string[] = process.argv, welcome = true): Promise<void> {
@@ -430,7 +437,7 @@ export async function run(args: string[] = process.argv, welcome = true): Promis
 
     if (welcome) {
         await cli.welcome({
-            skipDeepLinkCheck: invocation.args[0] === 'deep-link',
+            skipDeepLinkCheck: isDeepLinkCommand(invocation.args),
         });
     }
 


### PR DESCRIPTION
## Summary
This PR fixes deep links on macOS and relocates the deep-link command under the enable/disable command to improve scalability as new flags are introduced. The command changes from croct deep-link enable to croct enable deep-link.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings