### PR TITLE
Add support for scoped NPM URLs

### DIFF
--- a/src/application/cli/command/template/use.ts
+++ b/src/application/cli/command/template/use.ts
@@ -62,7 +62,8 @@ export class UseTemplateCommand implements Command<UseTemplateInput> {
         let path = name;
 
         if (URL.canParse(name)) {
-            const url = new URL(name);
+            // Ensure compatibility with URLs like npm://@scope/package
+            const url = new URL(name.replace(/(?<=^[a-z]+:\/*)([^/.:]+)/i, match => match.replace(/@/g, '%40')));
 
             if (url.protocol !== 'file:') {
                 return url;

--- a/src/application/provider/resource/npmRegistryProvider.ts
+++ b/src/application/provider/resource/npmRegistryProvider.ts
@@ -68,7 +68,7 @@ export class NpmRegistryProvider implements ResourceProvider<Mapping[]> {
             return null;
         }
 
-        const name = url.pathname.slice(1);
+        const name = decodeURIComponent(url.hostname) + url.pathname;
 
         return new URL(`https://registry.npmjs.org/${name}/latest`);
     }

--- a/src/application/provider/resource/npmRegistryProvider.ts
+++ b/src/application/provider/resource/npmRegistryProvider.ts
@@ -68,7 +68,11 @@ export class NpmRegistryProvider implements ResourceProvider<Mapping[]> {
             return null;
         }
 
-        const name = decodeURIComponent(url.hostname) + url.pathname;
+        let name = decodeURIComponent(url.hostname + url.pathname);
+
+        if (name.startsWith('/')) {
+            name = name.slice(1);
+        }
 
         return new URL(`https://registry.npmjs.org/${name}/latest`);
     }

--- a/src/application/template/action/importAction.ts
+++ b/src/application/template/action/importAction.ts
@@ -162,7 +162,7 @@ export class ImportAction implements Action<ImportOptions> {
             return await provider.get(url);
         } catch (error) {
             if (error instanceof ResourceNotFoundError) {
-                throw new HelpfulError(`No template found at \`${url}\`.`, {
+                throw new HelpfulError(`No template found at \`${decodeURIComponent(url.toString())}\`.`, {
                     cause: error,
                     reason: ErrorReason.INVALID_INPUT,
                     suggestions: [


### PR DESCRIPTION
## Summary
The current NPM resolution logic doesn't account for scoped packages that start with `@`. Since `@` is not a valid character in hostnames, the `URL` object strips it out.

This PR fixes the issue by percent-encoding `@` in the hostname and decoding it during URL resolution.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings