### PR TITLE
Improve error handling

### DIFF
--- a/src/application/cli/form/organization/organizationForm.ts
+++ b/src/application/cli/form/organization/organizationForm.ts
@@ -121,6 +121,8 @@ export class OrganizationForm implements Form<Organization, OrganizationOptions>
             3000,
         );
 
+        interval.unref();
+
         return {
             confirm: (status, details): void => {
                 clearInterval(interval);

--- a/src/application/template/action/changeDirectoryAction.ts
+++ b/src/application/template/action/changeDirectoryAction.ts
@@ -26,10 +26,19 @@ export class ChangeDirectoryAction implements Action<ChangeDirectoryOptions> {
         this.currentDirectory = currentDirectory;
     }
 
-    public execute(options: ChangeDirectoryOptions): Promise<void> {
+    public async execute(options: ChangeDirectoryOptions): Promise<void> {
         const target = this.fileSystem.isAbsolutePath(options.path)
             ? options.path
             : this.fileSystem.joinPaths(this.currentDirectory.get(), options.path);
+
+        if (!await this.fileSystem.isDirectory(target)) {
+            throw new ActionError(`Target path \`${options.path}\` is not a directory.`, {
+                reason: ErrorReason.INVALID_INPUT,
+                details: [
+                    `Target path: ${options.path}`,
+                ],
+            });
+        }
 
         if (!this.fileSystem.isSubPath(this.rootDirectory, target)) {
             throw new ActionError('Cannot change to a directory outside the current working directory.', {

--- a/src/application/template/action/executePackage.ts
+++ b/src/application/template/action/executePackage.ts
@@ -30,7 +30,8 @@ export type Configuration = {
     packageManagerProvider: Provider<PackageManager, [string]>,
     workingDirectory: WorkingDirectory,
     commandExecutor: CommandExecutor,
-    commandTimeout: number,
+    commandTotalTimeout: number,
+    commandUpdateTimeout: number,
 };
 
 export class ExecutePackage implements Action<ExecutePackageOptions> {
@@ -97,7 +98,7 @@ export class ExecutePackage implements Action<ExecutePackageOptions> {
         }
     }
 
-    private getPackageManager(name?: string): Promise<PackageManager>|PackageManager {
+    private getPackageManager(name?: string): Promise<PackageManager> | PackageManager {
         if (name === undefined) {
             return this.configuration.packageManager;
         }
@@ -108,11 +109,11 @@ export class ExecutePackage implements Action<ExecutePackageOptions> {
     }
 
     private async executeCommand(command: Command, interactions: Interactions[] = []): Promise<void> {
-        const {workingDirectory, commandExecutor, commandTimeout} = this.configuration;
+        const {workingDirectory, commandExecutor, commandTotalTimeout} = this.configuration;
 
         const execution = await commandExecutor.run(command, {
             workingDirectory: workingDirectory.get(),
-            timeout: commandTimeout,
+            timeout: commandTotalTimeout,
         });
 
         const nextInteractions = [...interactions];
@@ -123,7 +124,13 @@ export class ExecutePackage implements Action<ExecutePackageOptions> {
 
         let buffer = '';
 
+        let timer: NodeJS.Timeout | null = null;
+
         for await (const line of execution.output) {
+            if (timer !== null) {
+                clearTimeout(timer);
+            }
+
             buffer += stripAnsi(line);
 
             for (const [index, interaction] of nextInteractions.entries()) {
@@ -151,21 +158,33 @@ export class ExecutePackage implements Action<ExecutePackageOptions> {
                     break;
                 }
             }
+
+            timer = setTimeout(
+                (): void => {
+                    execution.kill();
+                },
+                this.configuration.commandUpdateTimeout,
+            );
+        }
+
+        if (timer !== null) {
+            clearTimeout(timer);
         }
 
         let exitCode = -1;
-        let executionError: any;
 
         try {
             exitCode = await execution.wait();
         } catch (error) {
-            executionError = error;
+            throw new ActionError('Command execution failed.', {
+                reason: ErrorReason.UNEXPECTED_RESULT,
+                cause: error,
+            });
         }
 
         if (exitCode !== 0) {
             throw new ActionError(`Command failed with output:\n\n${buffer}`, {
                 reason: ErrorReason.UNEXPECTED_RESULT,
-                cause: executionError,
             });
         }
     }

--- a/src/infrastructure/application/cli/cli.ts
+++ b/src/infrastructure/application/cli/cli.ts
@@ -724,7 +724,7 @@ export class Cli {
         const command = this.getUseTemplateCommand();
         const output = this.getOutput();
 
-        const notifier = output.notify('Loading template');
+        const notifier = output.notify('Loading template options');
 
         try {
             return await command.getOptions(template);
@@ -1042,7 +1042,8 @@ export class Cli {
                         packageManagerProvider: this.getPackageManagerRegistry(),
                         workingDirectory: this.workingDirectory,
                         commandExecutor: this.getAsynchronousCommandExecutor(),
-                        commandTimeout: 2 * 60 * 1000, // 2 minutes
+                        commandTotalTimeout: 5 * 60 * 1000, // 5 minutes
+                        commandUpdateTimeout: 30 * 1000, // 30 seconds
                         sourceChecker: {
                             test: (url): boolean => url.protocol === 'file:'
                                 || `${url}`.startsWith('https://github.com/croct-tech'),

--- a/src/infrastructure/application/cli/io/interactiveTaskMonitor.ts
+++ b/src/infrastructure/application/cli/io/interactiveTaskMonitor.ts
@@ -184,6 +184,8 @@ class TaskWatcher {
             },
             80,
         );
+
+        this.interval.unref();
     }
 
     private clear(): void {


### PR DESCRIPTION
## Summary
This PR improves error handling in the `spawn` executor and the `change-directory` action. The bug described in https://github.com/croct-tech/templates/pull/38 was difficult to diagnose due to several issues:

- The loading log for the template remained active for the entire process, preventing Node from exiting on errors and making it seem like the process was still running.
- The `change-directory` action did not verify whether the target directory existed before attempting to set it.
- As a result, `spawn` failed with a misleading `ENOENT` error. While this typically indicates a missing executable, in this case, it was caused by a non-existent working directory due to entering the wrong path.
- The `spawn` executor also failed to properly check for errors from the `wait` call, allowing the promise to resolve even on failure.

This PR introduces several improvements to enhance error reporting and make failure modes easier to diagnose.
### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings