### PR TITLE
Add support for relative import

### DIFF
--- a/src/application/project/code/transformation/globImportCodemod.ts
+++ b/src/application/project/code/transformation/globImportCodemod.ts
@@ -70,8 +70,17 @@ export class GlobImportCodemod implements Codemod<string> {
     }
 
     private async resolvePath(declaration: ImportDeclaration, pattern: string, sourcePath: string): Promise<string> {
-        const matcher = new Minimatch(pattern);
         const rootPath = this.rootPath.get();
+        const matcher = new Minimatch(
+            pattern.startsWith('./')
+                ? `${this.fileSystem
+                    .getRelativePath(
+                        rootPath,
+                        this.fileSystem.getDirectoryName(sourcePath),
+                    )
+                    .replace(/[\\/]/g, '/')}/${pattern.slice(2)}`
+                : pattern,
+        );
 
         for await (const file of this.fileSystem.list(rootPath, this.maxSearchDepth)) {
             if (


### PR DESCRIPTION
## Summary
This PR introduces support for the ?/ prefix to explicitly mark relative imports as potentially resolvable within the same folder. Previously, we relied on glob patterns like ?/**/*, which could lead to ambiguous or incorrect matches when importing common filenames (e.g., page.module.css) that exist in multiple locations. 

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings