### PR TITLE
Add support for automatic type erasure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "@babel/core": "^7.25.7",
         "@babel/generator": "^7.25.9",
         "@babel/parser": "^7.25.7",
+        "@babel/plugin-syntax-decorators": "^7.27.1",
+        "@babel/plugin-transform-typescript": "^7.27.1",
         "@babel/types": "^7.25.9",
         "@croct/cache": "^0.4.2",
         "@croct/content": "^1.0.0",
@@ -138,13 +140,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.26.2",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
-      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.27.1",
         "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
+        "picocolors": "^1.1.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -196,15 +198,26 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.0.tgz",
-      "integrity": "sha512-VybsKvpiN1gU1sdMZIp7FcqphVVKEwcuj02x73uvcHE0PTihx1nlBcowYWhDwjpoAXRv43+gDzyggGnn1XZhVw==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.1.tgz",
+      "integrity": "sha512-UnJfnIpc/+JO0/+KRVQNGU+y5taA5vCbwN8+azkX6beii/ZF+enZJSOKo11ZSzGJjlNfJHfQtmQT8H+9TXPG2w==",
       "dependencies": {
-        "@babel/parser": "^7.27.0",
-        "@babel/types": "^7.27.0",
+        "@babel/parser": "^7.27.1",
+        "@babel/types": "^7.27.1",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-annotate-as-pure": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.1.tgz",
+      "integrity": "sha512-WnuuDILl9oOBbKnb4L+DyODx7iC47XfzmNCpTttFsSp6hTG7XZxu60+4IO+2/hPfcGOoKbFiwoI/+zwARbNQow==",
+      "dependencies": {
+        "@babel/types": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -231,6 +244,46 @@
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-create-class-features-plugin": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.27.1.tgz",
+      "integrity": "sha512-QwGAmuvM17btKU5VqXfb+Giw4JcN0hjuufz3DYnpeVDvZLAObloM77bhMXiqry3Iio+Ai4phVRDwl6WU10+r5A==",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.1",
+        "@babel/helper-member-expression-to-functions": "^7.27.1",
+        "@babel/helper-optimise-call-expression": "^7.27.1",
+        "@babel/helper-replace-supers": "^7.27.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/traverse": "^7.27.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-create-class-features-plugin/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.27.1.tgz",
+      "integrity": "sha512-E5chM8eWjTp/aNoVpcbfM7mLxu9XGLWYise2eBKGQomAk/Mb4XoxyqXTZbuTohbsl8EKqdlMhnDI2CCLfcs9wA==",
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
@@ -261,27 +314,65 @@
         "@babel/core": "^7.0.0"
       }
     },
+    "node_modules/@babel/helper-optimise-call-expression": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
+      "integrity": "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==",
+      "dependencies": {
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.26.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.26.5.tgz",
-      "integrity": "sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==",
-      "dev": true,
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
+      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-replace-supers": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.27.1.tgz",
+      "integrity": "sha512-7EHz6qDZc8RYS5ElPoShMheWvEgERonFCs7IAonWLLUTXW59DP14bCZt89/GKyreYn8g3S83m21FelHKbeDCKA==",
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^7.27.1",
+        "@babel/helper-optimise-call-expression": "^7.27.1",
+        "@babel/traverse": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
+      "integrity": "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==",
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
-      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -307,11 +398,11 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
-      "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.1.tgz",
+      "integrity": "sha512-I0dZ3ZpCrJ1c04OqlNsQcKiZlsrXf/kkE4FXzID9rIOYICsAbA8mMDzhW/luRNAHdCNt7os/u8wenklZDlUVUQ==",
       "dependencies": {
-        "@babel/types": "^7.27.0"
+        "@babel/types": "^7.27.1"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -363,6 +454,20 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-decorators": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.27.1.tgz",
+      "integrity": "sha512-YMq8Z87Lhl8EGkmb0MwYkt36QnxC+fzCgrl66ereamPlYToRpIk5nUjKUY3QKLWq8mwUB1BgbeXcTJhZOCDg5A==",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -543,12 +648,29 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.9.tgz",
-      "integrity": "sha512-hjMgRy5hb8uJJjUcdWunWVcoi9bGpJp8p5Ol1229PoN6aytsLwNMgmdftO23wnCLMfVmTwZDWMPNq/D1SY60JQ==",
-      "dev": true,
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz",
+      "integrity": "sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-typescript": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.27.1.tgz",
+      "integrity": "sha512-Q5sT5+O4QUebHdbwKedFBEwRLb02zJ7r4A5Gg2hUoLuU3FjdMcyqcywqUrLCaDsFCxzokf7u9kuy7qz51YUuAg==",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.1",
+        "@babel/helper-create-class-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/plugin-syntax-typescript": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -570,28 +692,28 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
-      "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.1.tgz",
+      "integrity": "sha512-Fyo3ghWMqkHHpHQCoBs2VnYjR4iWFFjguTDEqA5WgZDOrFesVjMhMM2FSqTKSoUSDO1VQtavj8NFpdRBEvJTtg==",
       "dependencies": {
-        "@babel/code-frame": "^7.26.2",
-        "@babel/parser": "^7.27.0",
-        "@babel/types": "^7.27.0"
+        "@babel/code-frame": "^7.27.1",
+        "@babel/parser": "^7.27.1",
+        "@babel/types": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.0.tgz",
-      "integrity": "sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.1.tgz",
+      "integrity": "sha512-ZCYtZciz1IWJB4U61UPu4KEaqyfj+r5T1Q5mqPo+IBpcG9kHv30Z0aD8LXPgC1trYa6rK0orRyAhqUgk4MjmEg==",
       "dependencies": {
-        "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.27.0",
-        "@babel/parser": "^7.27.0",
-        "@babel/template": "^7.27.0",
-        "@babel/types": "^7.27.0",
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.27.1",
+        "@babel/parser": "^7.27.1",
+        "@babel/template": "^7.27.1",
+        "@babel/types": "^7.27.1",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -600,12 +722,12 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
-      "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.1.tgz",
+      "integrity": "sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.25.9",
-        "@babel/helper-validator-identifier": "^7.25.9"
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "@babel/core": "^7.25.7",
     "@babel/generator": "^7.25.9",
     "@babel/parser": "^7.25.7",
+    "@babel/plugin-syntax-decorators": "^7.27.1",
+    "@babel/plugin-transform-typescript": "^7.27.1",
     "@babel/types": "^7.25.9",
     "@croct/cache": "^0.4.2",
     "@croct/content": "^1.0.0",

--- a/src/application/project/code/transformation/javascript/typeErasureCodemod.ts
+++ b/src/application/project/code/transformation/javascript/typeErasureCodemod.ts
@@ -1,0 +1,102 @@
+import {File, Comment, noop} from '@babel/types';
+import type {VisitNodeObject, Node} from '@babel/traverse';
+import {transformFromAstAsync, createConfigItem} from '@babel/core';
+import bts from '@babel/plugin-transform-typescript';
+import bsd from '@babel/plugin-syntax-decorators';
+import {Codemod, ResultCode} from '@/application/project/code/transformation/codemod';
+import {isTypescript} from '@/application/project/code/transformation/javascript/utils/isTypescript';
+
+export type TypeErasureCodemodOptions = Record<string, never>;
+
+export class TypeErasureCodemod implements Codemod<File, TypeErasureCodemodOptions> {
+    public async apply(file: File): Promise<ResultCode<File>> {
+        if (!isTypescript(file)) {
+            return {
+                modified: false,
+                result: file,
+            };
+        }
+
+        const babelTsTransform = createConfigItem([bts, {onlyRemoveTypeImports: true}]);
+        const babelDecoratorSyntax = createConfigItem([bsd, {legacy: true}]);
+
+        // When removing TS-specific constructs (e.g., interfaces),
+        // ensure that any comments associated with those constructs are also removed.
+        // Otherwise, leftover comments might reference nonexistent code.
+        const removeComments: VisitNodeObject<unknown, Node> = {
+            enter: function visit(nodePath) {
+                const leadingComments = nodePath.node.leadingComments ?? nodePath.node.innerComments ?? null;
+
+                if (leadingComments === null) {
+                    return;
+                }
+
+                const preservedComments: Comment[] = [];
+
+                for (const comment of leadingComments) {
+                    const tokens = comment.loc?.tokens ?? [];
+                    const tokenIndex = tokens.findIndex(
+                        candidate => (
+                            candidate.loc?.start === comment.loc?.start
+                            && candidate.loc?.end === comment.loc?.end
+                        ),
+                    );
+
+                    if (tokenIndex >= 0 && tokenIndex < tokens.length - 1) {
+                        const commentToken = tokens[tokenIndex];
+                        const nextToken = tokens.find(
+                            (candidate, index) => (
+                                index > tokenIndex
+                                && !['CommentLine', 'CommentBlock'].includes(candidate.type)
+                            ),
+                        );
+
+                        if (nextToken === undefined) {
+                            continue;
+                        }
+
+                        const difference = nextToken.loc.start.line - commentToken.loc.end.line;
+
+                        if (difference > 1) {
+                            preservedComments.push(comment);
+                        }
+                    }
+                }
+
+                if (preservedComments.length > 0) {
+                    const node = noop();
+
+                    node.comments = preservedComments;
+
+                    nodePath.insertBefore(node);
+                }
+            },
+        };
+
+        const result = await transformFromAstAsync(file, undefined, {
+            plugins: [
+                {
+                    name: 'comment-remover',
+                    visitor: {
+                        Program: removeComments,
+                        TSTypeAliasDeclaration: removeComments,
+                        TSInterfaceDeclaration: removeComments,
+                        TSDeclareFunction: removeComments,
+                        TSDeclareMethod: removeComments,
+                        TSImportType: removeComments,
+                        TSModuleDeclaration: removeComments,
+                    },
+                },
+                babelTsTransform,
+                babelDecoratorSyntax,
+            ],
+            ast: true,
+            configFile: false,
+        });
+
+        return {
+            result: result?.ast ?? file,
+            modified: (result?.ast ?? null) !== null,
+        };
+    }
+}

--- a/src/application/project/code/transformation/javascript/utils/isTypescript.ts
+++ b/src/application/project/code/transformation/javascript/utils/isTypescript.ts
@@ -1,0 +1,34 @@
+import {File, Node, isTypeScript, isImportDeclaration, isImportSpecifier} from '@babel/types';
+import {traverse} from '@babel/core';
+import {parse} from '@/application/project/code/transformation/javascript/utils/parse';
+
+export function isTypescript(source: string | File): boolean {
+    const ast = typeof source === 'string'
+        ? parse(source, ['jsx', 'typescript'])
+        : source;
+
+    let matched = false;
+
+    traverse(ast, {
+        enter: path => {
+            const {node} = path;
+
+            if (isTypeScriptNode(node)) {
+                matched = true;
+
+                return path.stop();
+            }
+        },
+    });
+
+    return matched;
+}
+
+function isTypeScriptNode(node: Node): boolean {
+    return isTypeScript(node) || isTypeImport(node);
+}
+
+function isTypeImport(node: Node): boolean {
+    return (isImportSpecifier(node) || isImportDeclaration(node))
+      && (node.importKind === 'type' || node.importKind === 'typeof');
+}

--- a/src/application/project/code/transformation/pathBasedCodemod.ts
+++ b/src/application/project/code/transformation/pathBasedCodemod.ts
@@ -12,17 +12,18 @@ export class PathBasedCodemod<O extends CodemodOptions> implements Codemod<strin
         this.codemods = codemods;
     }
 
-    public apply(input: string, options?: O): Promise<ResultCode<string>> {
-        const [, codemod] = Object.entries(this.codemods)
-            .find(([pattern]) => minimatch(input, pattern)) ?? [];
+    public async apply(input: string, options?: O): Promise<ResultCode<string>> {
+        let result: ResultCode<string> = {
+            modified: false,
+            result: input,
+        };
 
-        if (codemod === undefined) {
-            return Promise.resolve({
-                modified: false,
-                result: input,
-            });
+        for (const [pattern, codemod] of Object.entries(this.codemods)) {
+            if (minimatch(input, pattern)) {
+                result = await codemod.apply(input, options);
+            }
         }
 
-        return codemod.apply(input, options);
+        return result;
     }
 }

--- a/src/extension.d.ts
+++ b/src/extension.d.ts
@@ -6,4 +6,24 @@ declare global {
     }
 }
 
+declare module '@babel/types' {
+    type Token = {
+        type: string,
+        value: string,
+        start: number,
+        end: number,
+        loc: SourceLocation,
+        leading: boolean,
+        trailing: boolean,
+    };
+
+    export interface SourceLocation {
+        tokens?: Token[];
+    }
+
+    export interface Noop {
+        comments?: Comment[];
+    }
+}
+
 export {};

--- a/src/infrastructure/application/cli/cli.ts
+++ b/src/infrastructure/application/cli/cli.ts
@@ -285,6 +285,7 @@ import {FirefoxRegistry} from '@/application/system/protocol/firefoxRegistry';
 import {DeepLinkCommand, DeepLinkInput} from '@/application/cli/command/deep-link';
 import {FileSystemTsConfigLoader} from '@/application/project/import/fileSystemTsConfigLoader';
 import {ResolvedCommandExecutor} from '@/infrastructure/application/system/command/resolvedCommandExecutor';
+import {TypeErasureCodemod} from '@/application/project/code/transformation/javascript/typeErasureCodemod';
 
 export type Configuration = {
     program: Program,
@@ -1084,6 +1085,19 @@ export class Cli {
                                                 return getExportedNames(code)
                                                     .some(name => names.includes(name));
                                             },
+                                        },
+                                    }),
+                                    new PathBasedCodemod({
+                                        codemods: {
+                                            '**/*.{js,jsx}': new ChainedCodemod(
+                                                new FileCodemod({
+                                                    fileSystem: fileSystem,
+                                                    codemod: new JavaScriptCodemod({
+                                                        codemod: new TypeErasureCodemod(),
+                                                        languages: ['typescript', 'jsx'],
+                                                    }),
+                                                }),
+                                            ),
                                         },
                                     }),
                                     new FormatCodemod(this.getJavaScriptFormatter()),

--- a/src/modules.d.ts
+++ b/src/modules.d.ts
@@ -1,0 +1,16 @@
+/* eslint-disable import/no-default-export -- It's external code */
+declare module '@babel/plugin-transform-typescript' {
+    import {PluginObj} from '@babel/core';
+
+    const plugin: () => PluginObj;
+
+    export default plugin;
+}
+
+declare module '@babel/plugin-syntax-decorators' {
+    import {PluginObj} from '@babel/core';
+
+    const plugin: () => PluginObj;
+
+    export default plugin;
+}

--- a/test/application/project/code/transformation/fixtures/ts-type-erasure/typescript-jsx.tsx
+++ b/test/application/project/code/transformation/fixtures/ts-type-erasure/typescript-jsx.tsx
@@ -1,0 +1,8 @@
+type AdditionProps = {
+    left: number;
+    right: number;
+}
+
+export function Addition(operands: AdditionProps): React.ReactElement {
+    return <div>{operands.left + operands.right}</div>;
+}

--- a/test/application/project/code/transformation/fixtures/ts-type-erasure/typescript-line-comments.ts
+++ b/test/application/project/code/transformation/fixtures/ts-type-erasure/typescript-line-comments.ts
@@ -1,0 +1,20 @@
+// The operands of the addition function.
+type AdditionOperands = {
+    /**
+     * The left operand.
+     */
+    left: number;
+    /**
+     * The right operand.
+     */
+    right: number;
+}
+
+/**
+ * This function takes two operands and returns their sum.
+ *
+ * @param operands
+ */
+export function addition(operands: AdditionOperands): number {
+    return operands.left + operands.right;
+}

--- a/test/application/project/code/transformation/fixtures/ts-type-erasure/typescript-multiline-comments.ts
+++ b/test/application/project/code/transformation/fixtures/ts-type-erasure/typescript-multiline-comments.ts
@@ -1,0 +1,22 @@
+/**
+ * The operands of the addition function.
+ */
+type AdditionOperands = {
+    /**
+     * The left operand.
+     */
+    left: number;
+    /**
+     * The right operand.
+     */
+    right: number;
+}
+
+/**
+ * This function takes two operands and returns their sum.
+ *
+ * @param operands
+ */
+export function addition(operands: AdditionOperands): number {
+    return operands.left + operands.right;
+}

--- a/test/application/project/code/transformation/fixtures/ts-type-erasure/typescript-preserve-comment.ts
+++ b/test/application/project/code/transformation/fixtures/ts-type-erasure/typescript-preserve-comment.ts
@@ -1,0 +1,25 @@
+/**
+ * Unrelated comment
+ */
+/**
+ * The operands of the addition function.
+ */
+type AdditionOperands = {
+    /**
+     * The left operand.
+     */
+    left: number;
+    /**
+     * The right operand.
+     */
+    right: number;
+}
+
+/**
+ * This function takes two operands and returns their sum.
+ *
+ * @param operands
+ */
+export function addition(operands: AdditionOperands): number {
+    return operands.left + operands.right;
+}

--- a/test/application/project/code/transformation/fixtures/ts-type-erasure/typescript-preserve-multiple-comments.ts
+++ b/test/application/project/code/transformation/fixtures/ts-type-erasure/typescript-preserve-multiple-comments.ts
@@ -1,0 +1,34 @@
+// Unrelated comment
+
+/**
+ * Unrelated comment
+ */
+
+/**
+ * The operands of the addition function.
+ */
+type AdditionOperands = {
+    /**
+     * The left operand.
+     */
+    left: number;
+    /**
+     * The right operand.
+     */
+    right: number;
+}
+
+// Another unrelated comment
+
+/**
+ * Another unrelated comment
+ */
+
+/**
+ * This function takes two operands and returns their sum.
+ *
+ * @param operands
+ */
+export function addition(operands: AdditionOperands): number {
+    return operands.left + operands.right;
+}

--- a/test/application/project/code/transformation/fixtures/ts-type-erasure/typescript.ts
+++ b/test/application/project/code/transformation/fixtures/ts-type-erasure/typescript.ts
@@ -1,0 +1,8 @@
+type AdditionOperands = {
+    left: number;
+    right: number;
+}
+
+export function addition(operands: AdditionOperands): number {
+    return operands.left + operands.right;
+}

--- a/test/application/project/code/transformation/javascript/__snapshots__/typeErasureCodemod.test.ts.snap
+++ b/test/application/project/code/transformation/javascript/__snapshots__/typeErasureCodemod.test.ts.snap
@@ -1,0 +1,72 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TypeErasureCodemod should correctly transform typescript.ts: typescript.ts 1`] = `
+"export function addition(operands) {
+    return operands.left + operands.right;
+}"
+`;
+
+exports[`TypeErasureCodemod should correctly transform typescript-jsx.tsx: typescript-jsx.tsx 1`] = `
+"export function Addition(operands) {
+    return <div>{operands.left + operands.right}</div>;
+}"
+`;
+
+exports[`TypeErasureCodemod should correctly transform typescript-line-comments.ts: typescript-line-comments.ts 1`] = `
+"/**
+ * This function takes two operands and returns their sum.
+ *
+ * @param operands
+ */
+export function addition(operands) {
+    return operands.left + operands.right;
+}"
+`;
+
+exports[`TypeErasureCodemod should correctly transform typescript-multiline-comments.ts: typescript-multiline-comments.ts 1`] = `
+"/**
+ * This function takes two operands and returns their sum.
+ *
+ * @param operands
+ */
+export function addition(operands) {
+    return operands.left + operands.right;
+}"
+`;
+
+exports[`TypeErasureCodemod should correctly transform typescript-preserve-comment.ts: typescript-preserve-comment.ts 1`] = `
+"/**
+ * Unrelated comment
+ */
+
+
+/**
+ * This function takes two operands and returns their sum.
+ *
+ * @param operands
+ */
+export function addition(operands) {
+    return operands.left + operands.right;
+}"
+`;
+
+exports[`TypeErasureCodemod should correctly transform typescript-preserve-multiple-comments.ts: typescript-preserve-multiple-comments.ts 1`] = `
+"// Unrelated comment
+/**
+ * Unrelated comment
+ */
+
+
+// Another unrelated comment
+/**
+ * Another unrelated comment
+ */
+/**
+ * This function takes two operands and returns their sum.
+ *
+ * @param operands
+ */
+export function addition(operands) {
+    return operands.left + operands.right;
+}"
+`;

--- a/test/application/project/code/transformation/javascript/typeErasureCodemod.test.ts
+++ b/test/application/project/code/transformation/javascript/typeErasureCodemod.test.ts
@@ -1,0 +1,19 @@
+import {resolve} from 'path';
+import {loadFixtures} from '../fixtures';
+import {JavaScriptCodemod} from '@/application/project/code/transformation/javascript/javaScriptCodemod';
+import {TypeErasureCodemod} from '@/application/project/code/transformation/javascript/typeErasureCodemod';
+
+describe('TypeErasureCodemod', () => {
+    const scenarios = loadFixtures(resolve(__dirname, '../fixtures/ts-type-erasure'), {}, {});
+
+    it.each(scenarios)('should correctly transform $name', async ({name, fixture}) => {
+        const transformer = new JavaScriptCodemod({
+            languages: ['typescript'],
+            codemod: new TypeErasureCodemod(),
+        });
+
+        const output = await transformer.apply(fixture);
+
+        expect(output.result).toMatchSnapshot(name);
+    });
+});

--- a/test/application/project/code/transformation/javascript/utils/isTypescript.test.ts
+++ b/test/application/project/code/transformation/javascript/utils/isTypescript.test.ts
@@ -1,0 +1,54 @@
+import {isTypescript} from '@/application/project/code/transformation/javascript/utils/isTypescript';
+
+describe('isTypescript', () => {
+    type Scenario = {
+        description: string,
+        code: string,
+        expected: boolean,
+    };
+
+    it.each<Scenario>([
+        {
+            description: 'match detect type import',
+            code: 'import type {Foo} from \'@croct/sdk\';',
+            expected: true,
+        },
+        {
+            description: 'match detect import type specifier',
+            code: 'import {type Foo} from \'@croct/sdk\';',
+            expected: true,
+        },
+        {
+            description: 'match detect types',
+            code: 'type Foo = {foo: string};',
+            expected: true,
+        },
+        {
+            description: 'match detect interface',
+            code: 'interface Foo {foo: string};',
+            expected: true,
+        },
+        {
+            description: 'match generic type',
+            code: 'class Foo<T> {foo: T};',
+            expected: true,
+        },
+        {
+            description: 'match type cast',
+            code: 'const foo = {} as Foo;',
+            expected: true,
+        },
+        {
+            description: 'match non-null assertion',
+            code: 'const foo = {}!;',
+            expected: true,
+        },
+        {
+            description: 'match type assertion',
+            code: 'const foo = (foo: any): foo is Foo => true;',
+            expected: true,
+        },
+    ])('should $description', ({code, expected}) => {
+        expect(isTypescript(code)).toBe(expected);
+    });
+});


### PR DESCRIPTION
## Summary
This PR adds support for automatic type erasure in TypeScript files.

Currently, to offer templates that work in both TypeScript and JavaScript, developers must maintain separate versions of each file—one typed, one untyped. This creates significant overhead and increases the maintenance burden, as every update must be mirrored manually.

With this change, when a downloaded file has a `.js` or `.jsx` extension, the `download` action will automatically remove all TypeScript-specific syntax if present, eliminating the need to maintain separate JS versions.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings