### PR TITLE
Add mirror

### DIFF
--- a/src/application/provider/resource/fetchProvider.ts
+++ b/src/application/provider/resource/fetchProvider.ts
@@ -2,7 +2,20 @@ import {HttpProvider, SuccessResponse} from '@/application/provider/resource/htt
 import {Resource, ResourceNotFoundError, ResourceProviderError} from '@/application/provider/resource/resourceProvider';
 import {ErrorReason} from '@/application/error';
 
+export type Configuration = {
+    retry?: {
+        delay?: number,
+        maxAttempts: number,
+    },
+};
+
 export class FetchProvider implements HttpProvider {
+    private readonly configuration: Configuration;
+
+    public constructor(configuration: Configuration = {}) {
+        this.configuration = configuration;
+    }
+
     public async get(url: URL): Promise<Resource<SuccessResponse>> {
         if (!['http:', 'https:'].includes(url.protocol)) {
             throw new ResourceProviderError(
@@ -14,23 +27,41 @@ export class FetchProvider implements HttpProvider {
             );
         }
 
+        return {
+            url: url,
+            value: await this.fetch(url),
+        };
+    }
+
+    private async fetch(url: URL, attempt: number = 0): Promise<SuccessResponse> {
         const response = await fetch(url);
 
         if (response.status === 404) {
             throw new ResourceNotFoundError('Resource not found.', {url: url});
         }
 
-        if (!FetchProvider.isSuccessful(response)) {
-            throw new ResourceProviderError(response.statusText, {url: url});
+        const {maxAttempts = 0, delay = 1000} = this.configuration.retry ?? {};
+
+        if (FetchProvider.isSuccessful(response)) {
+            return response;
         }
 
-        return {
-            url: url,
-            value: response,
-        };
+        if (FetchProvider.isRetryableCode(response.status) && attempt < maxAttempts) {
+            await new Promise(resolve => {
+                setTimeout(resolve, delay);
+            });
+
+            return this.fetch(url, attempt + 1);
+        }
+
+        throw new ResourceProviderError(response.statusText, {url: url});
     }
 
     private static isSuccessful(response: Response): response is SuccessResponse {
         return response.ok && response.body !== null;
+    }
+
+    private static isRetryableCode(code: number): boolean {
+        return code >= 500 || [429, 408].includes(code);
     }
 }

--- a/src/infrastructure/application/cli/cli.ts
+++ b/src/infrastructure/application/cli/cli.ts
@@ -1401,7 +1401,7 @@ export class Cli {
             this.getHttpProvider,
             () => new FetchProvider({
                 retry: {
-                    maxAttempts: 5,
+                    maxAttempts: 3,
                     delay: 1000,
                 },
             }),


### PR DESCRIPTION
## Summary
Some customers have experienced rate limits from GitHub due to the number of requests made when executing a template. This update introduces a mirror that first attempts to download files from our CDN, falling back to GitHub only if the files are not cached.

It also adds a retry mechanism that makes up to 3 attempts with a 1-second delay between each.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings