### PR TITLE
Fix package-manage discovery

### DIFF
--- a/src/application/predicate/executableExists.ts
+++ b/src/application/predicate/executableExists.ts
@@ -1,0 +1,22 @@
+import {Predicate} from '@/application/predicate/predicate';
+import {ExecutableLocator} from '@/application/system/executableLocator';
+
+export type Configuration = {
+    executableLocator: ExecutableLocator,
+    command: string,
+};
+
+export class ExecutableExists implements Predicate {
+    private readonly executableLocator: ExecutableLocator;
+
+    private readonly command: string;
+
+    public constructor({executableLocator, command}: Configuration) {
+        this.executableLocator = executableLocator;
+        this.command = command;
+    }
+
+    public async test(): Promise<boolean> {
+        return (await this.executableLocator.locate(this.command)) !== null;
+    }
+}

--- a/src/infrastructure/application/cli/cli.ts
+++ b/src/infrastructure/application/cli/cli.ts
@@ -286,6 +286,7 @@ import {DeepLinkCommand, DeepLinkInput} from '@/application/cli/command/deep-lin
 import {FileSystemTsConfigLoader} from '@/application/project/import/fileSystemTsConfigLoader';
 import {ResolvedCommandExecutor} from '@/infrastructure/application/system/command/resolvedCommandExecutor';
 import {TypeErasureCodemod} from '@/application/project/code/transformation/javascript/typeErasureCodemod';
+import {ExecutableExists} from '@/application/predicate/executableExists';
 
 export type Configuration = {
     program: Program,
@@ -1792,6 +1793,18 @@ export class Cli {
                                         files: lockFiles[name as keyof NodePackageManagers],
                                     }),
                                 ),
+                            }),
+                        ),
+                    }),
+                    // Finally, try to detect the package manager by the presence of the executable
+                    new ConditionalProvider({
+                        candidates: (Object.entries(managers)).map(
+                            ([name, manager]) => ({
+                                value: manager,
+                                condition: new ExecutableExists({
+                                    executableLocator: this.getExecutableLocator(),
+                                    command: name,
+                                }),
                             }),
                         ),
                     }),


### PR DESCRIPTION
## Summary
Running the CLI in a project without a lock file currently results in a "No package manager found" error. This happens because detection relies on either the `npm_config_user_agent` environment variable or the presence of a lock file—both of which are unavailable before the project is initialized.

This PR introduces a new detection method that checks for the package manager executable to improve reliability in uninitialized projects.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings