### PR TITLE
Add function to resolve URL

### DIFF
--- a/src/application/template/templateProvider.ts
+++ b/src/application/template/templateProvider.ts
@@ -285,7 +285,7 @@ export class TemplateProvider implements ResourceProvider<DeferredTemplate> {
             return await this.evaluator.evaluate(expression, {
                 variables: variables,
                 functions: {
-                    url: (url: JsonValue): Deferrable<JsonValue> => {
+                    url: (url: JsonValue = ''): Deferrable<JsonValue> => {
                         if (typeof url !== 'string') {
                             const location = node.location.start;
 

--- a/src/application/template/templateProvider.ts
+++ b/src/application/template/templateProvider.ts
@@ -285,6 +285,22 @@ export class TemplateProvider implements ResourceProvider<DeferredTemplate> {
             return await this.evaluator.evaluate(expression, {
                 variables: variables,
                 functions: {
+                    url: (url: JsonValue): Deferrable<JsonValue> => {
+                        if (typeof url !== 'string') {
+                            const location = node.location.start;
+
+                            throw new EvaluationError('Invalid argument for function `url`.', {
+                                reason: ErrorReason.INVALID_INPUT,
+                                details: [
+                                    'The `url` argument of the `url` function must be a string, '
+                                    + `but got ${HelpfulError.describeType(url)} at line ${location.line}, `
+                                    + `column ${location.column}.`,
+                                ],
+                            });
+                        }
+
+                        return resolveUrl(url, baseUrl).toString();
+                    },
                     import: (url?: JsonValue, properties?: JsonValue): Deferrable<JsonValue> => {
                         if (typeof url !== 'string') {
                             const location = node.location.start;


### PR DESCRIPTION
## Summary
This PR introduces a new url function that resolves a relative path into an absolute URL.

It’s particularly useful when passing URLs as arguments to other templates. If a relative URL is passed, it will be resolved relative to the URL of the executing template, which can lead to broken references if the asset doesn't exist in that context.

When called without arguments, the function returns the current URL.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings