### PR TITLE
Fix provider logic and improve error reporting

### DIFF
--- a/src/application/provider/resource/multiProvider.ts
+++ b/src/application/provider/resource/multiProvider.ts
@@ -15,6 +15,7 @@ export class MultiProvider<T> implements ResourceProvider<T> {
     private static readonly DEFAULT_EXPECTED_ERRORS: ErrorReason[] = [
         ErrorReason.NOT_SUPPORTED,
         ErrorReason.NOT_FOUND,
+        ErrorReason.OTHER,
     ];
 
     private readonly providers: Array<ResourceProvider<T>>;

--- a/src/infrastructure/application/cli/cli.ts
+++ b/src/infrastructure/application/cli/cli.ts
@@ -112,7 +112,7 @@ import {MultiProvider} from '@/application/provider/resource/multiProvider';
 import {FileSystemProvider} from '@/application/provider/resource/fileSystemProvider';
 import {GithubProvider} from '@/application/provider/resource/githubProvider';
 import {HttpFileProvider} from '@/application/provider/resource/httpFileProvider';
-import {ResourceProvider} from '@/application/provider/resource/resourceProvider';
+import {ResourceProvider, ResourceProviderError} from '@/application/provider/resource/resourceProvider';
 import {ErrorReason, HelpfulError} from '@/application/error';
 import {PartialNpmPackageValidator} from '@/infrastructure/application/validation/partialNpmPackageValidator';
 import {CroctConfigurationValidator} from '@/infrastructure/application/validation/croctConfigurationValidator';
@@ -2369,6 +2369,18 @@ export class Cli {
 
     private static handleError(error: unknown): any {
         switch (true) {
+            case error instanceof ResourceProviderError:
+                return new HelpfulError(
+                    error.message,
+                    {
+                        ...error.help,
+                        details: [
+                            `URL: ${error.url}`,
+                            ...(error.help.details ?? []),
+                        ],
+                    },
+                );
+
             case error instanceof ApiError:
                 if (error.isAccessDenied()) {
                     return new HelpfulError(


### PR DESCRIPTION
## Summary
Currently, when requesting a template, any error other than 404 is propagated upstream, preventing fallback to other providers. This PR updates the behavior to also attempt other providers if the error is classified as OTHER.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings