### PR TITLE
Fix Next.js version detection

### DIFF
--- a/src/application/project/sdk/plugNextSdk.ts
+++ b/src/application/project/sdk/plugNextSdk.ts
@@ -434,7 +434,7 @@ export class PlugNextSdk extends JavaScriptSdk {
         return parseNextJsConfig(config);
     }
 
-    private async isFallbackMode(): Promise<boolean> {
-        return !await this.packageManager.hasDirectDependency('next', '>=13');
+    private isFallbackMode(): Promise<boolean> {
+        return this.packageManager.hasDirectDependency('next', '<=13');
     }
 }


### PR DESCRIPTION
## Summary
This PR updates the logic used by the CLI to detect versions earlier than 13 and install the React SDK instead. It addresses an issue where the NPM `semver` package evaluates `15.0.0 >= 13` as false, while evaluating `12.0.0 <= 13` as true.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings