### PR TITLE
Add support for direct interaction with underlying CLIs

### DIFF
--- a/src/application/system/process/executor.ts
+++ b/src/application/system/process/executor.ts
@@ -34,7 +34,7 @@ export type ExecutionResult = {
 export type ExecutionOptions = {
     workingDirectory?: string,
     timeout?: number,
-    inheritInput?: boolean,
+    inheritIo?: boolean,
 };
 
 export interface CommandExecutor {

--- a/src/application/system/process/executor.ts
+++ b/src/application/system/process/executor.ts
@@ -34,6 +34,7 @@ export type ExecutionResult = {
 export type ExecutionOptions = {
     workingDirectory?: string,
     timeout?: number,
+    inheritInput?: boolean,
 };
 
 export interface CommandExecutor {

--- a/src/application/template/action/executePackage.ts
+++ b/src/application/template/action/executePackage.ts
@@ -122,7 +122,7 @@ export class ExecutePackage implements Action<ExecutePackageOptions> {
         const execution = await commandExecutor.run(command, {
             workingDirectory: workingDirectory.get(),
             timeout: commandTimeout,
-            inheritInput: interactions === true,
+            inheritIo: interactions === true,
         });
 
         let buffer = '';

--- a/src/infrastructure/application/system/command/spawnExecutor.ts
+++ b/src/infrastructure/application/system/command/spawnExecutor.ts
@@ -68,12 +68,12 @@ export class SpawnExecutor implements CommandExecutor, SynchronousCommandExecuto
             }
         });
 
-        const dataListeners = (data: Buffer): void => {
+        const dataListener = (data: Buffer): void => {
             output.push(data.toString());
         };
 
-        subprocess.stdout?.on('data', dataListeners);
-        subprocess.stderr?.on('data', dataListeners);
+        subprocess.stdout?.on('data', dataListener);
+        subprocess.stderr?.on('data', dataListener);
 
         const exitListeners: ExitCallback[] = [];
 

--- a/src/infrastructure/application/system/command/spawnExecutor.ts
+++ b/src/infrastructure/application/system/command/spawnExecutor.ts
@@ -41,7 +41,7 @@ export class SpawnExecutor implements CommandExecutor, SynchronousCommandExecuto
         const preparedCommand = this.prepareCommand(command);
 
         const subprocess = spawn(preparedCommand.name, preparedCommand.arguments ?? [], {
-            stdio: options.inheritInput === true ? 'inherit' : 'pipe',
+            stdio: options.inheritIo === true ? 'inherit' : 'pipe',
             shell: preparedCommand.shell,
             cwd: options?.workingDirectory ?? this.currentDirectory?.get(),
             signal: timeoutSignal,
@@ -180,7 +180,7 @@ export class SpawnExecutor implements CommandExecutor, SynchronousCommandExecuto
 
         const preparedCommand = this.prepareCommand(command);
         const subprocess = spawnSync(preparedCommand.name, preparedCommand.arguments, {
-            stdio: [options.inheritInput === true ? 'inherit' : 'ignore', 'pipe', 'pipe'],
+            stdio: [options.inheritIo === true ? 'inherit' : 'ignore', 'pipe', 'pipe'],
             cwd: options?.workingDirectory ?? this.currentDirectory?.get(),
             shell: preparedCommand.shell,
             signal: timeoutSignal,

--- a/src/infrastructure/application/validation/actions/executePackageOptionsValidator.ts
+++ b/src/infrastructure/application/validation/actions/executePackageOptionsValidator.ts
@@ -2,55 +2,59 @@ import {z, ZodType} from 'zod';
 import {ActionOptionsValidator} from '@/infrastructure/application/validation/actions/actionOptionsValidator';
 import {ExecutePackageOptions} from '@/application/template/action/executePackage';
 
+const interactionsSchemaList: ZodType<ExecutePackageOptions['interactions']> = z.array(
+    z.object({
+        when: z.string(),
+        pattern: z.boolean().optional(),
+        always: z.boolean().optional(),
+        then: z.array(z.string())
+            .min(1)
+            .optional(),
+        final: z.boolean().optional(),
+    }).superRefine((value, context) => {
+        if (value.then === undefined && value.final === undefined) {
+            context.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: 'Either `then` or `final` must be defined',
+            });
+        }
+
+        if (value.final === true && value.always === true) {
+            context.addIssue({
+                code: z.ZodIssueCode.custom,
+                path: ['always'],
+                message: 'Final interactions must have `always` set to `false`',
+            });
+        }
+
+        if (value.pattern === true) {
+            try {
+                // eslint-disable-next-line no-new -- Fastest way to validate a regular expression
+                new RegExp(value.when);
+            } catch {
+                context.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    path: ['pattern'],
+                    message: 'The `when` field must be a valid regular expression',
+                });
+            }
+        }
+    }),
+)
+    .min(1)
+    .optional()
+    .refine(value => value === undefined || value.some(interaction => interaction.final === true), {
+        message: 'At least one interaction must have `final` set to `true`',
+    });
+
 const schema: ZodType<ExecutePackageOptions> = z.strictObject({
     package: z.string(),
     arguments: z.array(z.string()).optional(),
     runner: z.string().optional(),
-    interactions: z.array(
-        z.object({
-            when: z.string(),
-            pattern: z.boolean().optional(),
-            always: z.boolean().optional(),
-            then: z.array(z.string())
-                .min(1)
-                .optional(),
-            final: z.boolean().optional(),
-        })
-            .superRefine((value, context) => {
-                if (value.then === undefined && value.final === undefined) {
-                    context.addIssue({
-                        code: z.ZodIssueCode.custom,
-                        message: 'Either `then` or `final` must be defined',
-                    });
-                }
-
-                if (value.final === true && value.always === true) {
-                    context.addIssue({
-                        code: z.ZodIssueCode.custom,
-                        path: ['always'],
-                        message: 'Final interactions must have `always` set to `false`',
-                    });
-                }
-
-                if (value.pattern === true) {
-                    try {
-                        // eslint-disable-next-line no-new -- Fastest way to validate a regular expression
-                        new RegExp(value.when);
-                    } catch {
-                        context.addIssue({
-                            code: z.ZodIssueCode.custom,
-                            path: ['pattern'],
-                            message: 'The `when` field must be a valid regular expression',
-                        });
-                    }
-                }
-            }),
-    )
-        .min(1)
-        .optional()
-        .refine(value => value === undefined || value.some(interaction => interaction.final === true), {
-            message: 'At least one interaction must have `final` set to `true`',
-        }),
+    interactions: z.union([
+        z.boolean(),
+        interactionsSchemaList,
+    ]),
 });
 
 export class ExecutePackageOptionsValidator extends ActionOptionsValidator<ExecutePackageOptions> {


### PR DESCRIPTION
## Summary
Until now, templates that needed to call an external CLI used the `execute-package` action, which abstracted all user interactions—either by providing default answers or selectively prompting only for relevant inputs—while forwarding them to the underlying CLI.

However, some upcoming integration templates require interaction with CLIs whose flows are too complex to wrap, such as those involving login processes. To support these cases, this PR introduces a new `interactions: true` option that allows the external CLI to fully take over the terminal by inheriting `stdin`, `stdout`, and `stderr`. Once the CLI finishes execution, control returns to the template flow.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings