### PR TITLE
Use replace instead of replaceAll

### DIFF
--- a/src/application/template/action/replaceFileContentAction.ts
+++ b/src/application/template/action/replaceFileContentAction.ts
@@ -63,7 +63,7 @@ export class ReplaceFileContentAction implements Action<ReplaceFileContentOption
         for (const {pattern, caseSensitive, value} of replacements) {
             const flags = caseSensitive === true ? 'gi' : 'g';
 
-            result = result.replaceAll(new RegExp(pattern, flags), `${value}`);
+            result = result.replace(new RegExp(pattern, flags), `${value}`);
         }
 
         return result;


### PR DESCRIPTION
## Summary
Replace `replaceAll` with `replace` to ensure compatibility with lookahead patterns, as `replaceAll` can behave inconsistently when used with zero-width assertions.


### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings