### PR TITLE
Add env vars for initialization

### DIFF
--- a/src/infrastructure/application/cli/cli.ts
+++ b/src/infrastructure/application/cli/cli.ts
@@ -478,6 +478,8 @@ export class Cli {
     }
 
     public init(input: InitInput): Promise<void> {
+        const {process} = this.configuration;
+
         return this.execute(
             new InitCommand({
                 sdkProvider: this.getSdkProvider(),
@@ -525,7 +527,13 @@ export class Cli {
                     output: this.getOutput(),
                 },
             }),
-            input,
+            {
+                ...input,
+                organization: process.getEnvValue('CROCT_ORGANIZATION') ?? input.organization ?? undefined,
+                workspace: process.getEnvValue('CROCT_WORKSPACE') ?? input.workspace ?? undefined,
+                devApplication: process.getEnvValue('CROCT_DEV_APPLICATION') ?? input.devApplication ?? undefined,
+                prodApplication: process.getEnvValue('CROCT_PROD_APPLICATION') ?? input.prodApplication ?? undefined,
+            },
         );
     }
 


### PR DESCRIPTION
## Summary
In some scenarios, especially when running the CLI in automated workflows, it's necessary to specify the organization, workspace, and application IDs in advance to set up the project without user interaction.

This PR enables that by supporting the environment variables `CROCT_ORGANIZATION`, `CROCT_WORKSPACE`, `CROCT_DEV_APPLICATION`, and `CROCT_PROD_APPLICATION`.


### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings