### PR TITLE
Add option to disable API key setup

### DIFF
--- a/src/application/cli/command/init.ts
+++ b/src/application/cli/command/init.ts
@@ -31,6 +31,7 @@ export type InitInput = {
     workspace?: string,
     devApplication?: string,
     prodApplication?: string,
+    skipApiKeySetup?: boolean,
 };
 
 export type InitConfig = {
@@ -157,7 +158,9 @@ export class InitCommand implements Command<InitInput> {
             return;
         }
 
-        await configurationManager.update(await this.configure(sdk, updatedConfiguration));
+        await configurationManager.update(
+            await this.configure(sdk, updatedConfiguration, input.skipApiKeySetup === true),
+        );
     }
 
     private async getOrganization(options: OrganizationOptions, organizationSlug?: string): Promise<Organization> {
@@ -247,7 +250,11 @@ export class InitCommand implements Command<InitInput> {
         return application;
     }
 
-    private async configure(sdk: Sdk, configuration: ProjectConfiguration): Promise<ProjectConfiguration> {
+    private async configure(
+        sdk: Sdk,
+        configuration: ProjectConfiguration,
+        skipApiKeySetup: boolean,
+    ): Promise<ProjectConfiguration> {
         const {skipConfirmation} = this.config;
 
         const updatedConfiguration = await sdk.setup({
@@ -255,6 +262,7 @@ export class InitCommand implements Command<InitInput> {
                 ? undefined
                 : this.config.io.input,
             output: this.config.io.output,
+            skipApiKeySetup: skipApiKeySetup,
             configuration: configuration,
         });
 

--- a/src/application/project/code/envFile.ts
+++ b/src/application/project/code/envFile.ts
@@ -53,15 +53,17 @@ export class EnvFile {
             return this.write(`${name}=${value}`);
         }
 
+        const entry = `${name}=${value}`;
+
         const updatedContent = content.replace(
             new RegExp(
                 `${escapedName}\\s*=\\s*((?!['"\`]).*$|\`(?:\\.|[^\`])*\`|'(?:\\.|[^'])*'|"(?:\\.|[^"])*")`,
                 'm',
             ),
-            `${name}=${value}`,
+            entry,
         );
 
-        if (updatedContent !== content) {
+        if (updatedContent !== content || updatedContent.includes(entry)) {
             return this.write(updatedContent);
         }
 

--- a/src/application/project/sdk/plugNextSdk.ts
+++ b/src/application/project/sdk/plugNextSdk.ts
@@ -337,31 +337,34 @@ export class PlugNextSdk extends JavaScriptSdk {
     private async updateEnvVariables(installation: NextInstallation): Promise<void> {
         const {project: {env: plan}, configuration, notifier} = installation;
 
-        if (!await plan.localFile.hasVariable(NextEnvVar.API_KEY)) {
-            notifier.update('Loading information');
+        notifier.update('Loading information');
 
-            const [user, developmentApplication, productionApplication] = await Promise.all([
-                this.userApi.getUser(),
-                this.workspaceApi.getApplication({
+        console.log(installation.skipApiKeySetup);
+
+        const [developmentApplication, productionApplication] = await Promise.all([
+            this.workspaceApi.getApplication({
+                organizationSlug: configuration.organization,
+                workspaceSlug: configuration.workspace,
+                applicationSlug: configuration.applications.development,
+            }),
+            configuration.applications.production === undefined
+                ? null
+                : this.workspaceApi.getApplication({
                     organizationSlug: configuration.organization,
                     workspaceSlug: configuration.workspace,
-                    applicationSlug: configuration.applications.development,
+                    applicationSlug: configuration.applications.production,
                 }),
-                configuration.applications.production === undefined
-                    ? null
-                    : this.workspaceApi.getApplication({
-                        organizationSlug: configuration.organization,
-                        workspaceSlug: configuration.workspace,
-                        applicationSlug: configuration.applications.production,
-                    }),
-            ]);
+        ]);
 
-            if (developmentApplication === null) {
-                throw new SdkError(
-                    `Development application \`${configuration.applications.development}\` not found.`,
-                    {reason: ErrorReason.NOT_FOUND},
-                );
-            }
+        if (developmentApplication === null) {
+            throw new SdkError(
+                `Development application \`${configuration.applications.development}\` not found.`,
+                {reason: ErrorReason.NOT_FOUND},
+            );
+        }
+
+        if (!await plan.localFile.hasVariable(NextEnvVar.API_KEY) && installation.skipApiKeySetup !== true) {
+            const user = await this.userApi.getUser();
 
             notifier.update('Creating API key');
 
@@ -391,18 +394,20 @@ export class PlugNextSdk extends JavaScriptSdk {
             await plan.localFile.setVariables({
                 [NextEnvVar.API_KEY]: apiKey.secret,
             });
-
-            await Promise.all([
-                plan.developmentFile.setVariables({
-                    [NextEnvVar.APP_ID]: developmentApplication.publicId,
-                }),
-                productionApplication === null
-                    ? Promise.resolve()
-                    : plan.productionFile.setVariables({
-                        [NextEnvVar.APP_ID]: productionApplication.publicId,
-                    }),
-            ]);
         }
+
+        // Always configure the app ID to ensure it matches the application
+        // defined in the project configuration
+        await Promise.all([
+            plan.developmentFile.setVariables({
+                [NextEnvVar.APP_ID]: developmentApplication.publicId,
+            }),
+            productionApplication === null
+                ? Promise.resolve()
+                : plan.productionFile.setVariables({
+                    [NextEnvVar.APP_ID]: productionApplication.publicId,
+                }),
+        ]);
     }
 
     private async detectRouter(directory?: string): Promise<NextRouter> {

--- a/src/application/project/sdk/sdk.ts
+++ b/src/application/project/sdk/sdk.ts
@@ -7,6 +7,7 @@ import {Help, HelpfulError} from '@/application/error';
 export type Installation = {
     input?: Input,
     output: Output,
+    skipApiKeySetup?: boolean,
     configuration: ProjectConfiguration,
 };
 

--- a/src/infrastructure/application/cli/cli.ts
+++ b/src/infrastructure/application/cli/cli.ts
@@ -529,10 +529,11 @@ export class Cli {
             }),
             {
                 ...input,
-                organization: process.getEnvValue('CROCT_ORGANIZATION') ?? input.organization ?? undefined,
-                workspace: process.getEnvValue('CROCT_WORKSPACE') ?? input.workspace ?? undefined,
-                devApplication: process.getEnvValue('CROCT_DEV_APPLICATION') ?? input.devApplication ?? undefined,
-                prodApplication: process.getEnvValue('CROCT_PROD_APPLICATION') ?? input.prodApplication ?? undefined,
+                organization: input.organization ?? process.getEnvValue('CROCT_ORGANIZATION') ?? undefined,
+                workspace: input.workspace ?? process.getEnvValue('CROCT_WORKSPACE') ?? undefined,
+                devApplication: input.devApplication ?? process.getEnvValue('CROCT_DEV_APPLICATION') ?? undefined,
+                prodApplication: input.prodApplication ?? process.getEnvValue('CROCT_PROD_APPLICATION') ?? undefined,
+                skipApiKeySetup: input.skipApiKeySetup ?? process.getEnvValue('CROCT_SKIP_API_KEY_SETUP') !== null,
             },
         );
     }

--- a/src/infrastructure/application/cli/program.ts
+++ b/src/infrastructure/application/cli/program.ts
@@ -119,6 +119,11 @@ function createProgram(config: Configuration): typeof program {
             new Option('-s, --sdk <platform>', 'The SDK to use.')
                 .choices(['javascript', 'react', 'next'] as const),
         )
+        .addOption(
+            new Option('--skip-api-key', 'Skip API key setup.')
+                .default(false)
+                .env('CROCT_SKIP_API_KEY_SETUP'),
+        )
         .addOption(config.interactive ? organizationOption : organizationOption.makeOptionMandatory())
         .addOption(config.interactive ? workspaceOption : workspaceOption.makeOptionMandatory())
         .addOption(config.interactive ? devApplicationOption : devApplicationOption.makeOptionMandatory())
@@ -149,6 +154,7 @@ function createProgram(config: Configuration): typeof program {
                 workspace: options.wor,
                 devApplication: options.devApp,
                 prodApplication: options.prodApp,
+                skipApiKeySetup: options.skipApiKey,
             });
         });
 


### PR DESCRIPTION
## Summary
This PR adds a new option and environment variable to disable API key setup during initialization. This prevents accidental leaks when scaffolding deployment-ready projects from templates, as the API key should instead be set via environment variables.

It also fixes an issue where setting an environment variable that already existed with the same value would result in duplication.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings