### PR TITLE
Fix authentication

### DIFF
--- a/src/application/cli/authentication/authenticator/cachedAuthenticator.ts
+++ b/src/application/cli/authentication/authenticator/cachedAuthenticator.ts
@@ -1,4 +1,5 @@
 import {CacheProvider} from '@croct/cache';
+import {deepEqual} from 'fast-equals';
 import {AuthenticationInput, Authenticator} from '@/application/cli/authentication/authenticator/index';
 
 export type Configuration<I extends AuthenticationInput>= {
@@ -12,40 +13,46 @@ export class CachedAuthenticator<I extends AuthenticationInput> implements Authe
 
     private readonly cacheKey: string;
 
-    private readonly cacheProvider: CacheProvider<string, string|null>;
+    private readonly tokenCache: CacheProvider<string, string|null>;
 
-    private promise?: Promise<string>;
+    private readonly inFlightCache: Map<I, Promise<string>> = new Map();
 
     public constructor({authenticator, cacheKey, cacheProvider}: Configuration<I>) {
         this.authenticator = authenticator;
         this.cacheKey = cacheKey;
-        this.cacheProvider = cacheProvider;
+        this.tokenCache = cacheProvider;
     }
 
     public getToken(): Promise<string|null> {
-        return this.cacheProvider.get(this.cacheKey, () => this.authenticator.getToken());
+        return this.tokenCache.get(this.cacheKey, () => this.authenticator.getToken());
     }
 
     public login(input: I): Promise<string> {
-        if (this.promise === undefined) {
-            this.promise = this.issueToken(input).finally(() => {
-                this.promise = undefined;
-            });
+        for (const [key, promise] of this.inFlightCache.entries()) {
+            if (deepEqual(input, key)) {
+                return promise;
+            }
         }
 
-        return this.promise;
+        const promise = this.issueToken(input).finally(() => {
+            this.inFlightCache.delete(input);
+        });
+
+        this.inFlightCache.set(input, promise);
+
+        return promise;
     }
 
     private async issueToken(input: I): Promise<string> {
         const token = await this.authenticator.login(input);
 
-        await this.cacheProvider.set(this.cacheKey, token);
+        await this.tokenCache.set(this.cacheKey, token);
 
         return token;
     }
 
     public async logout(): Promise<void> {
         await this.authenticator.logout();
-        await this.cacheProvider.delete(this.cacheKey);
+        await this.tokenCache.delete(this.cacheKey);
     }
 }


### PR DESCRIPTION
## Summary
This PR fixes an issue where running multiple parallel operations that require authentication caused the CLI to trigger overlapping authentication flows.

The CLI automatically handles authentication when an operation needs it. For example, `croct update` performs several parallel fetches that all require authentication. Previously, each fetch initiated its own authentication process, leading to a chaotic experience with overlapping logs and prompts.

To address this, the authenticator now uses a shared in-flight cache. Parallel authentication attempts will share the same promise, ensuring a single, consistent authentication flow.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings