### PR TITLE
Refactor codemod

### DIFF
--- a/src/infrastructure/application/cli/cli.ts
+++ b/src/infrastructure/application/cli/cli.ts
@@ -1733,13 +1733,14 @@ export class Cli {
                                         codemod: new JavaScriptCodemod({
                                             languages: ['typescript', 'jsx'],
                                             codemod: new NextJsMiddlewareCodemod({
+                                                // eslint-disable-next-line max-len -- Ignore for readability
+                                                matcherPattern: '/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)',
                                                 import: {
                                                     module: '@croct/plug-next/middleware',
                                                     middlewareName: 'middleware',
                                                     middlewareFactoryName: 'withCroct',
                                                     configName: 'config',
                                                     matcherName: 'matcher',
-                                                    matcherLocalName: 'croctMatcher',
                                                 },
                                             }),
                                         }),

--- a/test/application/project/code/transformation/fixtures/nextjs-middleware/existingConfigArrayMatcher.ts
+++ b/test/application/project/code/transformation/fixtures/nextjs-middleware/existingConfigArrayMatcher.ts
@@ -1,0 +1,3 @@
+export const config = {
+    matcher: ['/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)'],
+}

--- a/test/application/project/code/transformation/fixtures/nextjs-middleware/existingConfigMatcher.ts
+++ b/test/application/project/code/transformation/fixtures/nextjs-middleware/existingConfigMatcher.ts
@@ -1,5 +1,3 @@
-import { matcher } from "@croct/plug-next/middleware";
-
 export const config = {
-    matcher: matcher,
+    matcher: '/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)',
 }

--- a/test/application/project/code/transformation/fixtures/nextjs-middleware/existingImport.ts
+++ b/test/application/project/code/transformation/fixtures/nextjs-middleware/existingImport.ts
@@ -1,4 +1,4 @@
-import { withCroct, matcher } from "@croct/plug-next/middleware";
+import { withCroct } from "@croct/plug-next/middleware";
 
 export function middleware() {
     console.log('middleware');

--- a/test/application/project/code/transformation/fixtures/nextjs-middleware/existingImportAliased.ts
+++ b/test/application/project/code/transformation/fixtures/nextjs-middleware/existingImportAliased.ts
@@ -1,4 +1,4 @@
-import { withCroct as croctMiddleware, matcher as croctMatcher } from "@croct/plug-next/middleware";
+import { withCroct as croctMiddleware } from "@croct/plug-next/middleware";
 
 export function middleware() {
     console.log('middleware');

--- a/test/application/project/code/transformation/fixtures/nextjs-middleware/existingMiddlewareAndAliasedConfigMatcher.ts
+++ b/test/application/project/code/transformation/fixtures/nextjs-middleware/existingMiddlewareAndAliasedConfigMatcher.ts
@@ -1,9 +1,0 @@
-import { matcher as croctMatcher } from "@croct/plug-next/middleware";
-
-export const config = {
-    matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)', croctMatcher],
-}
-
-export default function () {
-    console.log('middleware');
-}

--- a/test/application/project/code/transformation/fixtures/nextjs-middleware/existingMiddlewareAndConfigArrayMatcher.ts
+++ b/test/application/project/code/transformation/fixtures/nextjs-middleware/existingMiddlewareAndConfigArrayMatcher.ts
@@ -1,9 +1,0 @@
-import { matcher } from "@croct/plug-next/middleware";
-
-export const config = {
-    matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)', matcher],
-}
-
-export default function () {
-    console.log('middleware');
-}

--- a/test/application/project/code/transformation/javascript/__snapshots__/nextJsMiddlewareCodemod.test.ts.snap
+++ b/test/application/project/code/transformation/javascript/__snapshots__/nextJsMiddlewareCodemod.test.ts.snap
@@ -1,11 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`NextJsMiddlewareCodemod should correctly transform configAfterDefaultExport.ts: configAfterDefaultExport.ts 1`] = `
-"import { withCroct, matcher } from "@croct/plug-next/middleware";
+"import { withCroct } from "@croct/plug-next/middleware";
 import type { NextRequest } from 'next/server'
 
 export const config = {
-    matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)', matcher],
+    matcher: [
+        '/((?!api|_next/static|_next/image|favicon.ico).*)',
+        "/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)"
+    ],
 }
 
 export const middleware = withCroct({
@@ -19,7 +22,7 @@ export const middleware = withCroct({
 `;
 
 exports[`NextJsMiddlewareCodemod should correctly transform configAfterMiddlewareWithReference.ts: configAfterMiddlewareWithReference.ts 1`] = `
-"import { withCroct, matcher } from "@croct/plug-next/middleware";
+"import { withCroct } from "@croct/plug-next/middleware";
 import type { NextRequest } from 'next/server'
 
 // pattern
@@ -42,7 +45,7 @@ const currentMatcher = getMatcher();
 const currentConfig = {
     matcher: [
         ...(Array.isArray(currentMatcher) ? currentMatcher : [currentMatcher]),
-        matcher
+        "/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)"
     ],
 }
 
@@ -75,11 +78,14 @@ export const config = currentConfig;
 `;
 
 exports[`NextJsMiddlewareCodemod should correctly transform configAfterNamedExport.ts: configAfterNamedExport.ts 1`] = `
-"import { withCroct, matcher } from "@croct/plug-next/middleware";
+"import { withCroct } from "@croct/plug-next/middleware";
 import type { NextRequest } from 'next/server'
 
 export const config = {
-    matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)', matcher],
+    matcher: [
+        '/((?!api|_next/static|_next/image|favicon.ico).*)',
+        "/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)"
+    ],
 }
 
 export default withCroct({
@@ -105,11 +111,14 @@ export const config = bar;
 `;
 
 exports[`NextJsMiddlewareCodemod should correctly transform configWithArrayMatcher.ts: configWithArrayMatcher.ts 1`] = `
-"import { withCroct, matcher } from "@croct/plug-next/middleware";
+"import { withCroct } from "@croct/plug-next/middleware";
 import type { NextRequest } from 'next/server'
 
 export const config = {
-    matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)', matcher],
+    matcher: [
+        '/((?!api|_next/static|_next/image|favicon.ico).*)',
+        "/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)"
+    ],
 }
 
 export const middleware = withCroct({
@@ -123,11 +132,14 @@ export const middleware = withCroct({
 `;
 
 exports[`NextJsMiddlewareCodemod should correctly transform configWithIndirectVariableReference.ts: configWithIndirectVariableReference.ts 1`] = `
-"import { withCroct, matcher } from "@croct/plug-next/middleware";
+"import { withCroct } from "@croct/plug-next/middleware";
 const regex = '/((?!api|_next/static|_next/image|favicon.ico).*)';
 
 const configValue = {
-    matcher: [...(Array.isArray(regex) ? regex : [regex]), matcher],
+    matcher: [
+        ...(Array.isArray(regex) ? regex : [regex]),
+        "/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)"
+    ],
 }
 
 const indirectReference = configValue;
@@ -144,10 +156,13 @@ export const middleware = withCroct({
 `;
 
 exports[`NextJsMiddlewareCodemod should correctly transform configWithStringMatcher.ts: configWithStringMatcher.ts 1`] = `
-"import { withCroct, matcher } from "@croct/plug-next/middleware";
+"import { withCroct } from "@croct/plug-next/middleware";
 
 export const config = {
-    matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)', matcher],
+    matcher: [
+        '/((?!api|_next/static|_next/image|favicon.ico).*)',
+        "/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)"
+    ],
 }
 
 export const middleware = withCroct({
@@ -161,11 +176,14 @@ export const middleware = withCroct({
 `;
 
 exports[`NextJsMiddlewareCodemod should correctly transform configWithVariableMatcher.ts: configWithVariableMatcher.ts 1`] = `
-"import { withCroct, matcher } from "@croct/plug-next/middleware";
+"import { withCroct } from "@croct/plug-next/middleware";
 const regex = '/((?!api|_next/static|_next/image|favicon.ico).*)';
 
 export const config = {
-    matcher: [...(Array.isArray(regex) ? regex : [regex]), matcher],
+    matcher: [
+        ...(Array.isArray(regex) ? regex : [regex]),
+        "/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)"
+    ],
 }
 
 export const middleware = withCroct({
@@ -179,11 +197,14 @@ export const middleware = withCroct({
 `;
 
 exports[`NextJsMiddlewareCodemod should correctly transform configWithVariableReference.ts: configWithVariableReference.ts 1`] = `
-"import { withCroct, matcher } from "@croct/plug-next/middleware";
+"import { withCroct } from "@croct/plug-next/middleware";
 const regex = '/((?!api|_next/static|_next/image|favicon.ico).*)';
 
 const configValue = {
-    matcher: [...(Array.isArray(regex) ? regex : [regex]), matcher],
+    matcher: [
+        ...(Array.isArray(regex) ? regex : [regex]),
+        "/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)"
+    ],
 }
 
 export const config = configValue;
@@ -319,10 +340,26 @@ export default middleware(function () {
 `;
 
 exports[`NextJsMiddlewareCodemod should correctly transform existingConfig.ts: existingConfig.ts 1`] = `
-"import { withCroct, matcher } from "@croct/plug-next/middleware";
+"import { withCroct } from "@croct/plug-next/middleware";
 
 export const config = {
-    matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)', matcher],
+    matcher: [
+        '/((?!api|_next/static|_next/image|favicon.ico).*)',
+        "/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)"
+    ],
+}
+
+export default withCroct({
+    matcher: config.matcher
+});
+"
+`;
+
+exports[`NextJsMiddlewareCodemod should correctly transform existingConfigArrayMatcher.ts: existingConfigArrayMatcher.ts 1`] = `
+"import { withCroct } from "@croct/plug-next/middleware";
+
+export const config = {
+    matcher: ['/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)'],
 }
 
 export default withCroct({
@@ -332,10 +369,10 @@ export default withCroct({
 `;
 
 exports[`NextJsMiddlewareCodemod should correctly transform existingConfigMatcher.ts: existingConfigMatcher.ts 1`] = `
-"import { matcher, withCroct } from "@croct/plug-next/middleware";
+"import { withCroct } from "@croct/plug-next/middleware";
 
 export const config = {
-    matcher: matcher,
+    matcher: '/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)',
 }
 
 export default withCroct({
@@ -359,10 +396,13 @@ export default withCroct(function () {
 `;
 
 exports[`NextJsMiddlewareCodemod should correctly transform existingImport.ts: existingImport.ts 1`] = `
-"import { withCroct, matcher } from "@croct/plug-next/middleware";
+"import { withCroct } from "@croct/plug-next/middleware";
 
 export const config = {
-    matcher: ['.*', matcher]
+    matcher: [
+        '.*',
+        "/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)"
+    ]
 };
 
 export const middleware = withCroct({
@@ -376,10 +416,13 @@ export const middleware = withCroct({
 `;
 
 exports[`NextJsMiddlewareCodemod should correctly transform existingImportAliased.ts: existingImportAliased.ts 1`] = `
-"import { withCroct as croctMiddleware, matcher as croctMatcher } from "@croct/plug-next/middleware";
+"import { withCroct as croctMiddleware } from "@croct/plug-next/middleware";
 
 export const config = {
-    matcher: ['.*', croctMatcher]
+    matcher: [
+        '.*',
+        "/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)"
+    ]
 };
 
 export const middleware = croctMiddleware({
@@ -398,40 +441,6 @@ exports[`NextJsMiddlewareCodemod should correctly transform existingLocalConfigA
 export const config = {
     matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)'],
 }
-"
-`;
-
-exports[`NextJsMiddlewareCodemod should correctly transform existingMiddlewareAndAliasedConfigMatcher.ts: existingMiddlewareAndAliasedConfigMatcher.ts 1`] = `
-"import { matcher as croctMatcher, withCroct } from "@croct/plug-next/middleware";
-
-export const config = {
-    matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)', croctMatcher],
-}
-
-export default withCroct({
-    matcher: config.matcher,
-
-    next: function() {
-        console.log('middleware');
-    }
-});
-"
-`;
-
-exports[`NextJsMiddlewareCodemod should correctly transform existingMiddlewareAndConfigArrayMatcher.ts: existingMiddlewareAndConfigArrayMatcher.ts 1`] = `
-"import { matcher, withCroct } from "@croct/plug-next/middleware";
-
-export const config = {
-    matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)', matcher],
-}
-
-export default withCroct({
-    matcher: config.matcher,
-
-    next: function() {
-        console.log('middleware');
-    }
-});
 "
 `;
 
@@ -455,10 +464,13 @@ exports[`NextJsMiddlewareCodemod should correctly transform existingMiddlewareRe
 `;
 
 exports[`NextJsMiddlewareCodemod should correctly transform matcherAlias.ts: matcherAlias.ts 1`] = `
-"import { withCroct, matcher as croctMatcher } from "@croct/plug-next/middleware";
+"import { withCroct } from "@croct/plug-next/middleware";
 
 export const config = {
-    matcher: ['.*', croctMatcher]
+    matcher: [
+        '.*',
+        "/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)"
+    ]
 };
 
 export const middleware = withCroct({
@@ -505,10 +517,13 @@ export const middleware = withCroct(function() {
 `;
 
 exports[`NextJsMiddlewareCodemod should correctly transform namedSpecifiedExport.ts: namedSpecifiedExport.ts 1`] = `
-"import { withCroct, matcher } from "@croct/plug-next/middleware";
+"import { withCroct } from "@croct/plug-next/middleware";
 
 const config = {
-    matcher: ['.*', matcher]
+    matcher: [
+        '.*',
+        "/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)"
+    ]
 };
 
 const middleware = withCroct({
@@ -524,13 +539,16 @@ export { middleware, config };
 `;
 
 exports[`NextJsMiddlewareCodemod should correctly transform specifiedExportWithAliases.ts: specifiedExportWithAliases.ts 1`] = `
-"import { withCroct, matcher } from "@croct/plug-next/middleware";
+"import { withCroct } from "@croct/plug-next/middleware";
 
 function unrelated() {
 }
 
 const _config = {
-    matcher: ['.*', matcher]
+    matcher: [
+        '.*',
+        "/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)"
+    ]
 };
 
 const _middlewareFn = withCroct({

--- a/test/application/project/code/transformation/javascript/nextJsMiddlewareCodemod.test.ts
+++ b/test/application/project/code/transformation/javascript/nextJsMiddlewareCodemod.test.ts
@@ -8,12 +8,12 @@ import {JavaScriptCodemod} from '@/application/project/code/transformation/javas
 
 describe('NextJsMiddlewareCodemod', () => {
     const defaultOptions: MiddlewareConfiguration = {
+        matcherPattern: '/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)',
         import: {
             module: '@croct/plug-next/middleware',
             middlewareFactoryName: 'withCroct',
             middlewareName: 'middleware',
             matcherName: 'matcher',
-            matcherLocalName: 'matcher',
             configName: 'config',
         },
     };
@@ -25,7 +25,6 @@ describe('NextJsMiddlewareCodemod', () => {
             'matcherAlias.ts': {
                 import: {
                     ...defaultOptions.import,
-                    matcherLocalName: 'croctMatcher',
                 },
             },
         },

--- a/test/application/template/templateStringParser.test.ts
+++ b/test/application/template/templateStringParser.test.ts
@@ -63,7 +63,7 @@ describe('A template string parser', () => {
                 value: 'Hello, world!',
                 token: new JsonTokenNode({
                     type: JsonTokenType.STRING,
-                    value: '"Hello, world!"',
+                    value: 'Hello, world!',
                     location: {
                         start: {
                             index: 10,


### PR DESCRIPTION
## Summary
The current Next middleware codemod inserts a constant reference in the matcher, which isn't supported because Next.js statically analyzes matchers by parsing the code.

This PR updates the behavior to use literal strings instead,.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings