### PR TITLE
Fix middleware codemod

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "esbuild-plugin-file-path-extensions": "^2.1.4",
         "eslint": "^8.0.0",
         "jest": "^29.7.0",
-        "tsup": "^8.4.0",
+        "tsup": "^8.1.0",
         "typescript": "^5.6.2"
       }
     },

--- a/test/application/project/code/transformation/fixtures/nextjs-middleware/existingConfigReexport.ts
+++ b/test/application/project/code/transformation/fixtures/nextjs-middleware/existingConfigReexport.ts
@@ -1,1 +1,0 @@
-export { config } from "@croct/plug-next/middleware";

--- a/test/application/project/code/transformation/fixtures/nextjs-middleware/existingLocalConfigAndMiddlewareReexport.ts
+++ b/test/application/project/code/transformation/fixtures/nextjs-middleware/existingLocalConfigAndMiddlewareReexport.ts
@@ -1,5 +1,0 @@
-export { middleware } from "@croct/plug-next/middleware";
-
-export const config = {
-    matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)'],
-}

--- a/test/application/project/code/transformation/fixtures/nextjs-middleware/existingMiddlewareAndConfigReexport.ts
+++ b/test/application/project/code/transformation/fixtures/nextjs-middleware/existingMiddlewareAndConfigReexport.ts
@@ -1,1 +1,0 @@
-export { middleware, config } from "@croct/plug-next/middleware";


### PR DESCRIPTION
## Summary
This PR fixes a wrong assumption: Next.js doesn't support reexporting middleware matchers. Matchers are now defined using literal strings instead.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings