### PR TITLE
Add support for partially defined project configurations

### DIFF
--- a/src/application/cli/command/install.ts
+++ b/src/application/cli/command/install.ts
@@ -1,11 +1,20 @@
 import {Command} from '@/application/cli/command/command';
 import {Output} from '@/application/cli/io/output';
 import {Input} from '@/application/cli/io/input';
-import {ConfigurationManager} from '@/application/project/configuration/manager/configurationManager';
+import {
+    ConfigurationManager,
+    InitializationState,
+} from '@/application/project/configuration/manager/configurationManager';
 import {Installation, Sdk} from '@/application/project/sdk/sdk';
+import {
+    ProjectConfiguration,
+    ProjectConfigurationError,
+} from '@/application/project/configuration/projectConfiguration';
+import {ErrorReason} from '@/application/error';
 
 export type InstallInput = {
     clean?: boolean,
+    partialConfiguration?: boolean,
 };
 
 export type InstallConfig = {
@@ -25,14 +34,67 @@ export class InstallCommand implements Command<InstallInput> {
     }
 
     public async execute(input: InstallInput): Promise<void> {
-        const {sdk, configurationManager, io} = this.configuration;
+        const {sdk, io} = this.configuration;
 
         const installation: Installation = {
             input: io.input,
             output: io.output,
-            configuration: await configurationManager.load(),
+            configuration: await this.getConfiguration(input.partialConfiguration ?? false),
         };
 
         await sdk.update(installation, {clean: input.clean});
+    }
+
+    private async getConfiguration(partial: boolean): Promise<ProjectConfiguration> {
+        const {configurationManager} = this.configuration;
+
+        if (!partial || await configurationManager.isInitialized(InitializationState.FULL)) {
+            return configurationManager.load();
+        }
+
+        // Partial configuration allows the install command to run when the project is only
+        // partially initialized.
+        // This is useful for template projects that have some slots or parts configured,
+        // but where values like organization, workspace, and applications must be defined when
+        // connecting to the actual workspace.
+        const {applications, ...partialConfiguration} = await configurationManager.loadPartial();
+
+        return {
+            paths: {},
+            slots: {},
+            components: {},
+            get organization(): string {
+                return InstallCommand.reportConfigurationError('organization');
+            },
+            get workspace(): string {
+                return InstallCommand.reportConfigurationError('workspace');
+            },
+            applications: {
+                get development(): string {
+                    return InstallCommand.reportConfigurationError('applications.development');
+                },
+                get production(): string {
+                    return InstallCommand.reportConfigurationError('applications.production');
+                },
+                ...applications,
+            },
+            get defaultLocale(): string {
+                return InstallCommand.reportConfigurationError('defaultLocale');
+            },
+            get locales(): string[] {
+                return InstallCommand.reportConfigurationError('locales');
+            },
+            ...partialConfiguration,
+        };
+    }
+
+    private static reportConfigurationError(property: string): never {
+        throw new ProjectConfigurationError(
+            `The \`${property}\` property is not defined in the project configuration.`,
+            {
+                reason: ErrorReason.INVALID_CONFIGURATION,
+                suggestions: ['Run `init` command to initialize the project configuration.'],
+            },
+        );
     }
 }

--- a/src/application/project/configuration/manager/cachedConfigurationManager.ts
+++ b/src/application/project/configuration/manager/cachedConfigurationManager.ts
@@ -1,5 +1,11 @@
-import {ProjectConfiguration} from '@/application/project/configuration/projectConfiguration';
-import {ConfigurationManager} from '@/application/project/configuration/manager/configurationManager';
+import {
+    PartialProjectConfiguration,
+    ProjectConfiguration,
+} from '@/application/project/configuration/projectConfiguration';
+import {
+    ConfigurationManager,
+    InitializationState,
+} from '@/application/project/configuration/manager/configurationManager';
 
 export class CachedConfigurationManager implements ConfigurationManager {
     private readonly manager: ConfigurationManager;
@@ -10,8 +16,8 @@ export class CachedConfigurationManager implements ConfigurationManager {
         this.manager = manager;
     }
 
-    public isInitialized(): Promise<boolean> {
-        return this.manager.isInitialized();
+    public isInitialized(state?: InitializationState): Promise<boolean> {
+        return this.manager.isInitialized(state);
     }
 
     public load(): Promise<ProjectConfiguration> {
@@ -20,6 +26,10 @@ export class CachedConfigurationManager implements ConfigurationManager {
         }
 
         return this.configuration;
+    }
+
+    public loadPartial(): Promise<PartialProjectConfiguration> {
+        return this.manager.loadPartial();
     }
 
     public update(configuration: ProjectConfiguration): Promise<ProjectConfiguration> {

--- a/src/application/project/configuration/manager/configurationManager.ts
+++ b/src/application/project/configuration/manager/configurationManager.ts
@@ -1,9 +1,20 @@
-import {ProjectConfiguration} from '@/application/project/configuration/projectConfiguration';
+import {
+    PartialProjectConfiguration,
+    ProjectConfiguration,
+} from '@/application/project/configuration/projectConfiguration';
+
+export enum InitializationState {
+    PARTIAL = 'partial',
+    FULL = 'full',
+    ANY = 'any',
+}
 
 export interface ConfigurationManager {
-    isInitialized(): Promise<boolean>;
+    isInitialized(state?: InitializationState): Promise<boolean>;
 
     load(): Promise<ProjectConfiguration>;
+
+    loadPartial(): Promise<PartialProjectConfiguration>;
 
     update(configuration: ProjectConfiguration): Promise<ProjectConfiguration>;
 }

--- a/src/application/project/configuration/manager/indexedConfigurationManager.ts
+++ b/src/application/project/configuration/manager/indexedConfigurationManager.ts
@@ -1,5 +1,11 @@
-import {ProjectConfiguration} from '@/application/project/configuration/projectConfiguration';
-import {ConfigurationManager} from '@/application/project/configuration/manager/configurationManager';
+import {
+    PartialProjectConfiguration,
+    ProjectConfiguration,
+} from '@/application/project/configuration/projectConfiguration';
+import {
+    ConfigurationManager,
+    InitializationState,
+} from '@/application/project/configuration/manager/configurationManager';
 import {WorkingDirectory} from '@/application/fs/workingDirectory/workingDirectory';
 import {CliConfigurationProvider} from '@/application/cli/configuration/provider';
 
@@ -22,12 +28,20 @@ export class IndexedConfigurationManager implements ConfigurationManager {
         this.configurationProvider = configurationProvider;
     }
 
-    public isInitialized(): Promise<boolean> {
-        return this.manager.isInitialized();
+    public isInitialized(state?: InitializationState): Promise<boolean> {
+        return this.manager.isInitialized(state);
     }
 
     public async load(): Promise<ProjectConfiguration> {
         const configuration = await this.manager.load();
+
+        await this.updateIndex();
+
+        return configuration;
+    }
+
+    public async loadPartial(): Promise<PartialProjectConfiguration> {
+        const configuration = this.manager.loadPartial();
 
         await this.updateIndex();
 

--- a/src/application/project/configuration/manager/newConfigurationManager.ts
+++ b/src/application/project/configuration/manager/newConfigurationManager.ts
@@ -1,5 +1,11 @@
-import {ProjectConfiguration} from '@/application/project/configuration/projectConfiguration';
-import {ConfigurationManager} from '@/application/project/configuration/manager/configurationManager';
+import {
+    PartialProjectConfiguration,
+    ProjectConfiguration,
+} from '@/application/project/configuration/projectConfiguration';
+import {
+    ConfigurationManager,
+    InitializationState,
+} from '@/application/project/configuration/manager/configurationManager';
 
 export interface ConfigurationInitializer {
     initialize(): Promise<void>;
@@ -20,16 +26,20 @@ export class NewConfigurationManager implements ConfigurationManager {
         this.initializer = initializer;
     }
 
-    public isInitialized(): Promise<boolean> {
-        return this.manager.isInitialized();
+    public isInitialized(state?: InitializationState): Promise<boolean> {
+        return this.manager.isInitialized(state);
     }
 
     public async load(): Promise<ProjectConfiguration> {
-        if (!await this.isInitialized()) {
+        if (!await this.isInitialized(InitializationState.FULL)) {
             await this.initializer.initialize();
         }
 
         return this.manager.load();
+    }
+
+    public loadPartial(): Promise<PartialProjectConfiguration> {
+        return this.manager.loadPartial();
     }
 
     public update(configuration: ProjectConfiguration): Promise<ProjectConfiguration> {

--- a/src/application/project/configuration/projectConfiguration.ts
+++ b/src/application/project/configuration/projectConfiguration.ts
@@ -22,6 +22,10 @@ export type ProjectConfiguration = {
     paths?: Partial<ProjectPaths>,
 };
 
+export type PartialProjectConfiguration = Partial<Omit<ProjectConfiguration, 'applications'>> & {
+    applications?: Partial<ProjectConfiguration['applications']>,
+};
+
 export class ProjectConfigurationError extends HelpfulError {
     public constructor(message: string, help: Help = {}) {
         super(message, {

--- a/src/application/project/sdk/javasScriptSdk.ts
+++ b/src/application/project/sdk/javasScriptSdk.ts
@@ -198,7 +198,7 @@ export abstract class JavaScriptSdk implements Sdk {
                 notifier.update('Registering script');
 
                 try {
-                    await this.packageManager.addScript('postinstall', 'croct install');
+                    await this.packageManager.addScript('postinstall', 'croct --no-interaction install');
 
                     notifier.confirm('Script registered');
                 } catch (error) {

--- a/src/infrastructure/application/cli/cli.ts
+++ b/src/infrastructure/application/cli/cli.ts
@@ -61,7 +61,10 @@ import {AddComponentCommand, AddComponentInput} from '@/application/cli/command/
 import {ComponentForm} from '@/application/cli/form/workspace/componentForm';
 import {RemoveSlotCommand, RemoveSlotInput} from '@/application/cli/command/slot/remove';
 import {RemoveComponentCommand, RemoveComponentInput} from '@/application/cli/command/component/remove';
-import {ConfigurationManager} from '@/application/project/configuration/manager/configurationManager';
+import {
+    ConfigurationManager,
+    InitializationState,
+} from '@/application/project/configuration/manager/configurationManager';
 import {NewConfigurationManager} from '@/application/project/configuration/manager/newConfigurationManager';
 import {InstallCommand, InstallInput} from '@/application/cli/command/install';
 import {PageForm} from '@/application/cli/form/page';
@@ -115,7 +118,10 @@ import {HttpFileProvider} from '@/application/provider/resource/httpFileProvider
 import {ResourceProvider, ResourceProviderError} from '@/application/provider/resource/resourceProvider';
 import {ErrorReason, HelpfulError} from '@/application/error';
 import {PartialNpmPackageValidator} from '@/infrastructure/application/validation/partialNpmPackageValidator';
-import {CroctConfigurationValidator} from '@/infrastructure/application/validation/croctConfigurationValidator';
+import {
+    FullCroctConfigurationValidator,
+    PartialCroctConfigurationValidator,
+} from '@/infrastructure/application/validation/croctConfigurationValidator';
 import {ValidatedProvider} from '@/application/provider/resource/validatedProvider';
 import {FileContentProvider} from '@/application/provider/resource/fileContentProvider';
 import {Json5Provider} from '@/application/provider/resource/json5Provider';
@@ -586,6 +592,11 @@ export class Cli {
     }
 
     public install(input: InstallInput): Promise<void> {
+        // Force partial configuration when running non-interactively or in DND mode.
+        // This skips prompts for missing project values and uses getters that throw errors
+        // if those values are accessed — useful for CI where missing info will fail fast if needed.
+        const partialConfiguration = !this.configuration.interactive || this.configuration.dnd;
+
         return this.execute(
             new InstallCommand({
                 sdk: this.getSdk(),
@@ -595,7 +606,10 @@ export class Cli {
                     output: this.getOutput(),
                 },
             }),
-            input,
+            {
+                clean: input.clean ?? false,
+                partialConfiguration: input.partialConfiguration ?? partialConfiguration,
+            },
         );
     }
 
@@ -1296,7 +1310,7 @@ export class Cli {
                         callback: async (): Promise<void> => {
                             const manager = this.getConfigurationManager();
 
-                            if (!await manager.isInitialized()) {
+                            if (!await manager.isInitialized(InitializationState.FULL)) {
                                 return this.init({});
                             }
                         },
@@ -2255,10 +2269,10 @@ export class Cli {
 
     private getConfigurationManager(): ConfigurationManager {
         return this.share(this.getConfigurationManager, () => {
-            const output = this.getOutput();
             const manager = new JsonConfigurationFileManager({
                 fileSystem: this.getFileSystem(),
-                validator: new CroctConfigurationValidator(),
+                fullValidator: new FullCroctConfigurationValidator(),
+                partialValidator: new PartialCroctConfigurationValidator(),
                 projectDirectory: this.workingDirectory,
             });
 
@@ -2270,10 +2284,7 @@ export class Cli {
                         ? new NewConfigurationManager({
                             manager: manager,
                             initializer: {
-                                initialize: async (): Promise<void> => {
-                                    await this.init({});
-                                    output.break();
-                                },
+                                initialize: () => this.init({}),
                             },
                         })
                         : manager,


### PR DESCRIPTION
## Summary

This PR adds support for the CLI to load partially defined configurations when running the `croct install` command in `--no-interaction` or `--dnd` modes. It also changes the default registered command to `croct --no-interaction install`.

This update is useful for scenarios like templates, where slots, paths, and other settings can be preconfigured while leaving organization, workspace, and related details to be connected later.

With this new behavior, whenever the CLI requires the full configuration, it will prompt the user to complete it. The CLI can now read these incomplete configurations and use them as defaults for the final setup.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings