### PR TITLE
Avoid dynamic import

### DIFF
--- a/src/application/project/code/transformation/javascript/javaScriptCodemod.ts
+++ b/src/application/project/code/transformation/javascript/javaScriptCodemod.ts
@@ -1,6 +1,6 @@
 import {File} from '@babel/types';
-import * as recast from 'recast';
-import {parse} from 'recast/parsers/babel-ts.js';
+import {parse, print} from 'recast';
+import {parse as babelParser} from 'recast/parsers/babel-ts.js';
 import {Codemod, CodemodOptions, ResultCode} from '@/application/project/code/transformation/codemod';
 import {Language} from '@/application/project/code/transformation/javascript/utils/parse';
 
@@ -17,9 +17,9 @@ export class JavaScriptCodemod<O extends CodemodOptions> implements Codemod<stri
     }
 
     public async apply(input: string, options?: O): Promise<ResultCode<string>> {
-        const ast = recast.parse(input, {
+        const ast = parse(input, {
             parser: {
-                parse: parse,
+                parse: babelParser,
             },
         });
 
@@ -34,7 +34,7 @@ export class JavaScriptCodemod<O extends CodemodOptions> implements Codemod<stri
 
         return {
             modified: true,
-            result: recast.print(result.result, {
+            result: print(result.result, {
                 reuseWhitespace: false,
             }).code,
         };

--- a/src/application/project/code/transformation/javascript/javaScriptCodemod.ts
+++ b/src/application/project/code/transformation/javascript/javaScriptCodemod.ts
@@ -1,6 +1,7 @@
 import {File} from '@babel/types';
 import {parse, print} from 'recast';
-import {parse as babelParser} from 'recast/parsers/babel-ts.js';
+import {parse as babelParse} from '@babel/parser';
+import getBabelOptions, {Overrides} from 'recast/parsers/_babel_options.js';
 import {Codemod, CodemodOptions, ResultCode} from '@/application/project/code/transformation/codemod';
 import {Language} from '@/application/project/code/transformation/javascript/utils/parse';
 
@@ -19,7 +20,13 @@ export class JavaScriptCodemod<O extends CodemodOptions> implements Codemod<stri
     public async apply(input: string, options?: O): Promise<ResultCode<string>> {
         const ast = parse(input, {
             parser: {
-                parse: babelParser,
+                parse: (source: string, parseOptions?: Overrides) => {
+                    const babelOptions = getBabelOptions(parseOptions);
+
+                    babelOptions.plugins.push('jsx', 'typescript');
+
+                    return babelParse(source, babelOptions);
+                },
             },
         });
 

--- a/src/application/project/code/transformation/javascript/javaScriptCodemod.ts
+++ b/src/application/project/code/transformation/javascript/javaScriptCodemod.ts
@@ -1,7 +1,7 @@
 import {File} from '@babel/types';
 import {parse, print} from 'recast';
 import {parse as babelParse} from '@babel/parser';
-import getBabelOptions, {Overrides} from 'recast/parsers/_babel_options.js';
+import getBabelOptions, {type Overrides} from 'recast/parsers/_babel_options.js';
 import {Codemod, CodemodOptions, ResultCode} from '@/application/project/code/transformation/codemod';
 import {Language} from '@/application/project/code/transformation/javascript/utils/parse';
 


### PR DESCRIPTION
## Summary
Avoid the dynamic import from recast.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings