### PR TITLE
Fix draft flag

### DIFF
--- a/src/infrastructure/application/api/graphql/workspace.ts
+++ b/src/infrastructure/application/api/graphql/workspace.ts
@@ -755,7 +755,7 @@ export class GraphqlWorkspaceApi implements WorkspaceApi {
                         : undefined,
                     content: GraphqlWorkspaceApi.createContentVariantGroup(experience.content),
                     validate: true,
-                    publish: experience.draft === false,
+                    publish: experience.draft !== true,
                 };
             }),
         };


### PR DESCRIPTION
## Summary
Previously, an experience would only publish if `draft` was `false`. This PR updates it to publish if `draft` is not strictly `false`.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings