### PR TITLE
Fix Storyblok init codemod

### DIFF
--- a/src/application/project/code/transformation/javascript/storyblokInitCodemod.ts
+++ b/src/application/project/code/transformation/javascript/storyblokInitCodemod.ts
@@ -45,33 +45,34 @@ export class StoryblokInitCodemod implements Codemod<t.File, StoryblokInitCodemo
             CallExpression: path => {
                 const {callee} = path.node;
 
-                // Match direct function calls: targetFunction(...)
-                if (t.isIdentifier(callee) && callee.name === 'storyblokInit') {
-                    path.node.arguments = [
-                        t.callExpression(
-                            t.identifier(wrapperName),
-                            path.node.arguments,
-                        ),
-                    ];
-
-                    modified = true;
-                }
-
-                // Match member expression calls: obj.targetFunction(...)
-                if (
-                    t.isMemberExpression(callee)
+                const isDirectCall = t.isIdentifier(callee) && callee.name === 'storyblokInit';
+                const isMemberCall = t.isMemberExpression(callee)
                     && t.isIdentifier(callee.property)
-                    && callee.property.name === 'storyblokInit'
-                ) {
-                    path.node.arguments = [
-                        t.callExpression(
-                            t.identifier(wrapperName),
-                            path.node.arguments,
-                        ),
-                    ];
+                    && callee.property.name === 'storyblokInit';
 
-                    modified = true;
+                if (!isDirectCall && !isMemberCall) {
+                    return;
                 }
+
+                const args = path.node.arguments;
+
+                if (
+                    args.length === 1
+                    && t.isCallExpression(args[0])
+                    && t.isIdentifier(args[0].callee)
+                    && args[0].callee.name === wrapperName
+                ) {
+                    return;
+                }
+
+                path.node.arguments = [
+                    t.callExpression(
+                        t.identifier(wrapperName),
+                        args,
+                    ),
+                ];
+
+                modified = true;
             },
         });
 

--- a/test/application/project/code/transformation/javascript/storyblokInitCodemod.test.ts
+++ b/test/application/project/code/transformation/javascript/storyblokInitCodemod.test.ts
@@ -199,6 +199,102 @@ describe('StoryblokInitCodemod', () => {
         ].join('\n'));
     });
 
+    it('should not wrap arguments that are already wrapped', async () => {
+        const transformer = createTransformer();
+
+        const input = [
+            "import { withCroct } from '@croct/storyblok';",
+            "import { storyblokInit } from '@storyblok/js';",
+            '',
+            'storyblokInit(withCroct({ accessToken: "token" }));',
+        ].join('\n');
+
+        const {result, modified} = await transformer.apply(input, {
+            name: 'withCroct',
+            module: '@croct/storyblok',
+        });
+
+        expect(modified).toBe(false);
+        expect(result).toBe(input);
+    });
+
+    it('should not wrap member expression arguments that are already wrapped', async () => {
+        const transformer = createTransformer();
+
+        const input = [
+            "import { withCroct } from '@croct/storyblok';",
+            "import * as sb from '@storyblok/js';",
+            '',
+            'sb.storyblokInit(withCroct({ accessToken: "token" }));',
+        ].join('\n');
+
+        const {result, modified} = await transformer.apply(input, {
+            name: 'withCroct',
+            module: '@croct/storyblok',
+        });
+
+        expect(modified).toBe(false);
+        expect(result).toBe(input);
+    });
+
+    it('should not wrap arguments that are already wrapped with an alias', async () => {
+        const transformer = createTransformer();
+
+        const input = [
+            "import { withCroct as croctWrapper } from '@croct/storyblok';",
+            "import { storyblokInit } from '@storyblok/js';",
+            '',
+            'storyblokInit(croctWrapper({ accessToken: "token" }));',
+        ].join('\n');
+
+        const {result, modified} = await transformer.apply(input, {
+            name: 'withCroct',
+            module: '@croct/storyblok',
+        });
+
+        expect(modified).toBe(false);
+        expect(result).toBe(input);
+    });
+
+    it('should not wrap arguments that are already wrapped with no arguments', async () => {
+        const transformer = createTransformer();
+
+        const input = [
+            "import { withCroct } from '@croct/storyblok';",
+            "import { storyblokInit } from '@storyblok/js';",
+            '',
+            'storyblokInit(withCroct());',
+        ].join('\n');
+
+        const {result, modified} = await transformer.apply(input, {
+            name: 'withCroct',
+            module: '@croct/storyblok',
+        });
+
+        expect(modified).toBe(false);
+        expect(result).toBe(input);
+    });
+
+    it('should wrap when the argument is a call to a different function', async () => {
+        const transformer = createTransformer();
+
+        const input = [
+            "import { storyblokInit } from '@storyblok/js';",
+            '',
+            'storyblokInit(otherWrapper({ accessToken: "token" }));',
+        ].join('\n');
+
+        const {result, modified} = await transformer.apply(input, {
+            name: 'withCroct',
+            module: '@croct/storyblok',
+        });
+
+        expect(modified).toBe(true);
+        expect(result).toContain(
+            'storyblokInit(withCroct(otherWrapper({ accessToken: "token" })));',
+        );
+    });
+
     it('should add empty statement before import when first statement is not an import', async () => {
         const transformer = createTransformer();
 


### PR DESCRIPTION
## Summary
The `StoryblokInitCodemod` was applying the wrapper function to `storyblokInit` arguments unconditionally, even when the wrapper was already present. This caused double-wrapping on repeated runs, producing code like `storyblokInit(withCroct(withCroct({...})))`.                                                                                                                                                                                    
                                                                                                                                                                                                                                   
The codemod now checks whether the single argument to `storyblokInit` is already a call to the wrapper function before transforming. This applies to both direct calls and aliased imports. 

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings