### PR TITLE
Resolve configuration file against the current working directory

### DIFF
--- a/src/application/project/configuration/manager/jsonConfigurationFileManager.ts
+++ b/src/application/project/configuration/manager/jsonConfigurationFileManager.ts
@@ -39,6 +39,8 @@ export class JsonConfigurationFileManager implements ConfigurationManager {
 
     private readonly fileSystem: FileSystem;
 
+    private readonly projectDirectory: WorkingDirectory;
+
     private readonly fullValidator: Validator<ProjectConfiguration>;
 
     private readonly partialValidator: Validator<PartialProjectConfiguration>;
@@ -47,6 +49,7 @@ export class JsonConfigurationFileManager implements ConfigurationManager {
 
     public constructor(configuration: Configuration) {
         this.fileSystem = configuration.fileSystem;
+        this.projectDirectory = configuration.projectDirectory;
         this.fullValidator = configuration.fullValidator;
         this.partialValidator = configuration.partialValidator;
         this.configurationFile = configuration.configurationFile;
@@ -54,7 +57,7 @@ export class JsonConfigurationFileManager implements ConfigurationManager {
 
     public async isInitialized(state: InitializationState = InitializationState.ANY): Promise<boolean> {
         if (state === InitializationState.ANY) {
-            return this.fileSystem.exists(this.configurationFile);
+            return this.fileSystem.exists(this.getConfigurationFilePath());
         }
 
         const validator = state === InitializationState.FULL
@@ -159,7 +162,7 @@ export class JsonConfigurationFileManager implements ConfigurationManager {
         validator: Validator<T>,
     ): Promise<LoadedFile<Omit<T, '$schema'>>> {
         const file: LoadedFile<T> = {
-            path: this.configurationFile,
+            path: this.getConfigurationFilePath(),
             source: null,
             configuration: null,
         };
@@ -182,6 +185,12 @@ export class JsonConfigurationFileManager implements ConfigurationManager {
         }
 
         return file;
+    }
+
+    private getConfigurationFilePath(): string {
+        return this.fileSystem.isAbsolutePath(this.configurationFile)
+            ? this.configurationFile
+            : this.fileSystem.joinPaths(this.projectDirectory.get(), this.configurationFile);
     }
 
     private async validateConfiguration<T extends JsonPartialProjectConfiguration>(

--- a/src/infrastructure/application/cli/cli.ts
+++ b/src/infrastructure/application/cli/cli.ts
@@ -2818,12 +2818,7 @@ export class Cli {
                 fullValidator: new FullCroctConfigurationValidator(),
                 partialValidator: new PartialCroctConfigurationValidator(),
                 projectDirectory: this.workingDirectory,
-                configurationFile: fileSystem.isAbsolutePath(this.configuration.configurationFile)
-                    ? this.configuration.configurationFile
-                    : fileSystem.joinPaths(
-                        this.workingDirectory.get(),
-                        this.configuration.configurationFile,
-                    ),
+                configurationFile: this.configuration.configurationFile,
             });
 
             return new IndexedConfigurationManager({

--- a/test/application/project/configuration/jsonConfigurationFileManager.test.ts
+++ b/test/application/project/configuration/jsonConfigurationFileManager.test.ts
@@ -1,0 +1,115 @@
+import type {FileSystem} from '@/application/fs/fileSystem';
+import type {Validator, ValidationResult} from '@/application/validation';
+import {VirtualizedWorkingDirectory} from '@/application/fs/workingDirectory/virtualizedWorkingDirectory';
+import type {
+    JsonProjectConfiguration,
+    JsonPartialProjectConfiguration,
+} from '@/application/project/configuration/manager/jsonConfigurationFileManager';
+import {JsonConfigurationFileManager} from '@/application/project/configuration/manager/jsonConfigurationFileManager';
+import type {ProjectConfiguration} from '@/application/project/configuration/projectConfiguration';
+
+describe('JsonConfigurationFileManager', () => {
+    const configuration: ProjectConfiguration = {
+        organization: 'org',
+        workspace: 'workspace',
+        applications: {
+            development: 'dev',
+        },
+        defaultLocale: 'en',
+        locales: ['en'],
+        slots: {},
+        components: {},
+    };
+
+    function createFileSystem(files: Map<string, string>): FileSystem {
+        return {
+            exists: (path: string): Promise<boolean> => Promise.resolve(files.has(path)),
+            readTextFile: (path: string): Promise<string> => {
+                const content = files.get(path);
+
+                if (content === undefined) {
+                    return Promise.reject(new Error(`File not found: ${path}`));
+                }
+
+                return Promise.resolve(content);
+            },
+            writeTextFile: (path: string, content: string): Promise<void> => {
+                files.set(path, content);
+
+                return Promise.resolve();
+            },
+            isAbsolutePath: (path: string): boolean => path.startsWith('/'),
+            joinPaths: (...paths: string[]): string => paths.join('/'),
+        } as Partial<FileSystem> as FileSystem;
+    }
+
+    function createValidator<T>(): Validator<T> {
+        return {
+            validate: (data: unknown): ValidationResult<T> => ({
+                valid: true,
+                data: data as T,
+            }),
+        };
+    }
+
+    it('should resolve the configuration file against the current project directory', async () => {
+        const files = new Map<string, string>();
+        const projectDirectory = new VirtualizedWorkingDirectory('/initial');
+
+        const manager = new JsonConfigurationFileManager({
+            fileSystem: createFileSystem(files),
+            projectDirectory: projectDirectory,
+            fullValidator: createValidator<JsonProjectConfiguration>(),
+            partialValidator: createValidator<JsonPartialProjectConfiguration>(),
+            configurationFile: 'croct.json',
+        });
+
+        projectDirectory.setCurrentDirectory('/initial/project');
+
+        await manager.update(configuration);
+
+        expect(files.has('/initial/croct.json')).toBe(false);
+        expect(files.has('/initial/project/croct.json')).toBe(true);
+    });
+
+    it('should load the configuration from the current project directory', async () => {
+        const files = new Map<string, string>();
+        const projectDirectory = new VirtualizedWorkingDirectory('/initial');
+
+        const manager = new JsonConfigurationFileManager({
+            fileSystem: createFileSystem(files),
+            projectDirectory: projectDirectory,
+            fullValidator: createValidator<JsonProjectConfiguration>(),
+            partialValidator: createValidator<JsonPartialProjectConfiguration>(),
+            configurationFile: 'croct.json',
+        });
+
+        files.set('/initial/project/croct.json', JSON.stringify(configuration));
+
+        await expect(manager.isInitialized()).resolves.toBe(false);
+
+        projectDirectory.setCurrentDirectory('/initial/project');
+
+        await expect(manager.isInitialized()).resolves.toBe(true);
+        await expect(manager.load()).resolves.toEqual(configuration);
+    });
+
+    it('should use an absolute configuration file path as given', async () => {
+        const files = new Map<string, string>();
+        const projectDirectory = new VirtualizedWorkingDirectory('/initial');
+
+        const manager = new JsonConfigurationFileManager({
+            fileSystem: createFileSystem(files),
+            projectDirectory: projectDirectory,
+            fullValidator: createValidator<JsonProjectConfiguration>(),
+            partialValidator: createValidator<JsonPartialProjectConfiguration>(),
+            configurationFile: '/custom/croct.json',
+        });
+
+        projectDirectory.setCurrentDirectory('/initial/project');
+
+        await manager.update(configuration);
+
+        expect(files.has('/custom/croct.json')).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary

Running a template that scaffolds a project and changes into it (e.g. `croct use croct://integration/sanity` in an empty folder) created `croct.json` in the folder the CLI was launched from instead of the project folder.

The cause: `JsonConfigurationFileManager` received the configuration file as an absolute path pre-joined with the working directory at instantiation time. Since the manager is a memoized singleton wired at startup, the path was frozen at the invocation directory — while the template's `change-directory` action only mutates the shared `VirtualizedWorkingDirectory`, which the manager never consulted again. Notably, the manager already declared a `projectDirectory` dependency that was never used.

The fix:
- `JsonConfigurationFileManager` now resolves the configuration file per operation: absolute paths are used as-is, relative ones are joined with `projectDirectory.get()` at call time.
- The CLI wiring passes the configured file name (default `croct.json`) through instead of pre-joining it.

## Test plan

- [x] New regression tests: reads and writes follow the current project directory; absolute path overrides stay pinned
- [x] Full suite passes (37 suites, 614 tests) and typecheck/lint clean
- [x] Verified with the built CLI in a temp directory: a template using `change-directory` now loads `croct.json` from the target folder; before the fix the same run failed to find the configuration and fell into the init flow at the launch directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)