### PR TITLE
Disable interaction when running in lifecycle scripts

### DIFF
--- a/src/infrastructure/application/cli/cli.ts
+++ b/src/infrastructure/application/cli/cli.ts
@@ -487,13 +487,13 @@ export class Cli {
 
     public static fromDefaults(configuration: Options): Cli {
         const appPaths = XDGAppPaths('com.croct.cli');
-        const process = new NodeProcess();
+        const process = configuration.process ?? new NodeProcess();
 
         return new Cli({
             program: configuration.program ?? ((): never => {
                 throw new HelpfulError('CLI is running in standalone mode.');
             }),
-            process: configuration.process ?? process,
+            process: process,
             quiet: configuration.quiet ?? false,
             debug: configuration.debug ?? false,
             stateless: configuration.stateless ?? ci.isCI,

--- a/src/infrastructure/application/cli/program.ts
+++ b/src/infrastructure/application/cli/program.ts
@@ -4,9 +4,12 @@ import {realpathSync} from 'fs';
 import {ApiKey} from '@croct/sdk/apiKey';
 import {Token} from '@croct/sdk/token';
 import {Cli} from '@/infrastructure/application/cli/cli';
+import {NodeProcess} from '@/infrastructure/application/system/nodeProcess';
+import type {Process} from '@/application/system/process/process';
 import type {Resource} from '@/application/cli/command/init';
 import type {OptionMap} from '@/application/template/template';
 import {ApiKeyPermission, ApplicationEnvironment} from '@/application/model/application';
+import {HasEnvVar} from '@/application/predicate/hasEnvVar';
 import packageJson from '@/../package.json';
 
 type Configuration = {
@@ -438,17 +441,28 @@ function isDeepLinkCommand(args: string[]): boolean {
     return args.length >= 2 && ['enable', 'disable'].includes(args[0]) && args[1] === 'deep-link';
 }
 
-export async function run(args: string[] = process.argv, welcome = true): Promise<void> {
-    const invocation = createProgram({interactive: true}).parse(args);
+export async function run(
+    args: string[] = process.argv,
+    welcome = true,
+    runtime: Process = new NodeProcess(),
+): Promise<void> {
+    const lifecycleScript = new HasEnvVar({
+        process: runtime,
+        variable: 'npm_lifecycle_event',
+        value: /^(?:pre|post)/,
+    }).test();
+    const invocation = createProgram({interactive: !lifecycleScript}).parse(args);
 
     const options = invocation.opts();
+    const interactive = options.interaction && !lifecycleScript;
 
     const cli = Cli.fromDefaults({
-        program: params => run(invocation.args.slice(0, 2).concat(params)),
+        process: runtime,
+        program: params => run(invocation.args.slice(0, 2).concat(params), true, runtime),
         version: packageJson.version,
         quiet: options.quiet,
         debug: options.debug,
-        interactive: options.interaction ? undefined : false,
+        interactive: interactive ? undefined : false,
         stateless: options.stateless,
         apiKey: options.apiKey,
         token: options.token,
@@ -467,7 +481,7 @@ export async function run(args: string[] = process.argv, welcome = true): Promis
 
     const program = createProgram({
         cli: cli,
-        interactive: options.interaction,
+        interactive: interactive,
         template: templateOptions,
     });
 

--- a/test/infrastructure/application/cli/program.test.ts
+++ b/test/infrastructure/application/cli/program.test.ts
@@ -1,0 +1,98 @@
+import type {Process} from '@/application/system/process/process';
+import {Cli} from '@/infrastructure/application/cli/cli';
+import {run} from '@/infrastructure/application/cli/program';
+
+jest.mock('clipboardy', () => ({}));
+jest.mock('is-installed-globally', () => false);
+jest.mock('is-plain-obj', () => jest.fn());
+jest.mock('strip-ansi', () => (value: string): string => value);
+
+jest.mock(
+    '@/infrastructure/application/cli/io/browserLinkOpener',
+    () => ({
+        BrowserLinkOpener: class {},
+    }),
+);
+
+jest.mock(
+    '@/infrastructure/application/cli/io/boxenFormatter',
+    () => ({
+        BoxenFormatter: class {},
+    }),
+);
+
+jest.mock(
+    '@/infrastructure/application/cli/io/formatting',
+    () => ({
+        colors: {},
+        format: jest.fn(),
+    }),
+);
+
+jest.mock(
+    '@/infrastructure/application/cli/io/interactiveTaskMonitor',
+    () => ({
+        InteractiveTaskMonitor: class {},
+    }),
+);
+
+jest.mock(
+    '@/infrastructure/application/evaluation/jsepExpressionEvaluator',
+    () => ({
+        JsepExpressionEvaluator: class {},
+    }),
+);
+
+describe('CLI program', () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it.each([
+        {event: 'preinstall', expected: false},
+        {event: 'prepare', expected: false},
+        {event: 'postinstall', expected: false},
+        {event: 'postbuild', expected: false},
+        {event: null, expected: undefined},
+        {event: '', expected: undefined},
+        {event: 'install', expected: undefined},
+        {event: 'build', expected: undefined},
+    ])('should configure interaction for lifecycle event $event', async ({event, expected}) => {
+        const factory = jest.spyOn(Cli, 'fromDefaults').mockReturnValue({logout: jest.fn()} as unknown as Cli);
+        const runtime = {
+            getEnvValue: (): string | null => event,
+        } as Partial<Process> as Process;
+
+        await run(['node', 'croct', 'logout'], false, runtime);
+
+        expect(factory).toHaveBeenCalledWith(expect.objectContaining({
+            process: runtime,
+            interactive: expected,
+        }));
+    });
+
+    it('should preserve the explicit non-interactive override', async () => {
+        const factory = jest.spyOn(Cli, 'fromDefaults').mockReturnValue({logout: jest.fn()} as unknown as Cli);
+        const runtime = {
+            getEnvValue: (): null => null,
+        } as Partial<Process> as Process;
+
+        await run(['node', 'croct', '--no-interaction', 'logout'], false, runtime);
+
+        expect(factory).toHaveBeenCalledWith(expect.objectContaining({
+            process: runtime,
+            interactive: false,
+        }));
+    });
+
+    it('should resolve the default directory from the injected process', () => {
+        const getCurrentDirectory = jest.fn(() => '/sentinel/project');
+        const runtime = {
+            getCurrentDirectory: getCurrentDirectory,
+        } as Partial<Process> as Process;
+
+        Cli.fromDefaults({process: runtime});
+
+        expect(getCurrentDirectory).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
## Summary

Package-manager lifecycle hooks can currently block dependency installation by asking unrelated interactive questions, such as whether to enable deep links. This is especially problematic for `pre*` and `post*` scripts, which must run unattended.

This change detects npm-compatible lifecycle context through `npm_lifecycle_event`. Event names beginning with the case-sensitive `pre` or `post` prefixes force the CLI into its existing non-interactive path. The requested command still executes normally, but optional prompts and host-environment changes remain suppressed.

The solution:

- injects a `Process` boundary into the CLI bootstrap and classifies lifecycle events with `HasEnvVar`;
- applies lifecycle precedence to both Commander construction passes, so conditional options and arguments are mandatory before execution;
- propagates the same process through recursive CLI invocations and `Cli.fromDefaults`;
- reuses the injected process for current-directory resolution instead of constructing another signal-subscribing `NodeProcess`;
- adds coverage for lifecycle, ordinary, missing, and explicit `--no-interaction` cases.

The existing SDK-generated `croct --no-interaction install` postinstall command remains unchanged as defense in depth.

## Verification

- `npm test -- --runInBand --runTestsByPath test/infrastructure/application/cli/program.test.ts` — 10 tests passed
- `npm run validate`
- `npm run lint`
- `npm run build`
- Lifecycle credential smoke test exited immediately with the mandatory `--username` diagnostic instead of prompting
- Lifecycle logout smoke test exited successfully without update or deep-link questions

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Documentation changes are not required for this internal bootstrap behavior
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing relevant unit tests pass locally with my changes
- [x] No downstream module changes are required
- [x] I have checked my code and corrected any misspellings