### PR TITLE
Report non-JSON API responses as they came

### DIFF
--- a/src/infrastructure/graphql/fetchGraphqlClient.ts
+++ b/src/infrastructure/graphql/fetchGraphqlClient.ts
@@ -48,25 +48,41 @@ export class FetchGraphqlClient implements GraphqlClient {
             }),
         });
 
-        return response.json().then(result => {
-            const {data, errors} = result as GraphqlResponseBody<TResult>;
+        const {data, errors} = await FetchGraphqlClient.parseBody<TResult>(response);
 
-            if (errors !== undefined) {
-                throw new ApiError(
-                    errors[0].message.replace(/"/g, '`'),
-                    errors.map(
-                        ({extensions}) => ({
-                            ...extensions,
-                            detail: extensions.detail?.replace(/"/g, '`'),
-                        }),
-                    ),
-                );
-            }
+        if (errors !== undefined) {
+            throw new ApiError(
+                errors[0].message.replace(/"/g, '`'),
+                errors.map(
+                    ({extensions}) => ({
+                        ...extensions,
+                        detail: extensions.detail?.replace(/"/g, '`'),
+                    }),
+                ),
+            );
+        }
 
-            return {
-                data: data,
-                headers: response.headers,
-            };
-        });
+        return {
+            data: data,
+            headers: response.headers,
+        };
+    }
+
+    private static async parseBody<TResult>(response: Response): Promise<GraphqlResponseBody<TResult>> {
+        const body = await response.text();
+
+        let payload: unknown;
+
+        try {
+            payload = JSON.parse(body);
+        } catch {
+            payload = null;
+        }
+
+        if (typeof payload !== 'object' || payload === null) {
+            throw new ApiError(body);
+        }
+
+        return payload as GraphqlResponseBody<TResult>;
     }
 }

--- a/test/infrastructure/graphql/fetchGraphqlClient.test.ts
+++ b/test/infrastructure/graphql/fetchGraphqlClient.test.ts
@@ -1,0 +1,129 @@
+import {TypedDocumentString} from '@/infrastructure/graphql/schema/graphql';
+import {FetchGraphqlClient} from '@/infrastructure/graphql/fetchGraphqlClient';
+import {ApiError, ProblemType} from '@/application/api/error';
+
+describe('A fetch GraphQL client', () => {
+    const endpoint = new URL('https://example.com/graphql');
+
+    type TestResult = {
+        greeting: string,
+    };
+
+    const query = new TypedDocumentString<TestResult, Record<string, never>>('query Test { greeting }');
+
+    it('should return the data from a valid payload', async () => {
+        jest.spyOn(globalThis, 'fetch').mockResolvedValue(
+            Response.json({
+                data: {
+                    greeting: 'Hello',
+                },
+            }),
+        );
+
+        const client = new FetchGraphqlClient({endpoint: endpoint});
+
+        await expect(client.execute(query)).resolves.toEqual({
+            headers: expect.any(Headers),
+            data: {
+                greeting: 'Hello',
+            },
+        });
+    });
+
+    it('should use the token provider and send the token', async () => {
+        const fetchMock = jest.spyOn(globalThis, 'fetch').mockResolvedValue(
+            Response.json({
+                data: {
+                    greeting: 'Hello',
+                },
+            }),
+        );
+
+        const getToken = jest.fn().mockResolvedValue('token-value');
+
+        const client = new FetchGraphqlClient({
+            endpoint: endpoint,
+            tokenProvider: {getToken: getToken},
+        });
+
+        await client.execute(query);
+
+        expect(getToken).toHaveBeenCalled();
+        expect(fetchMock).toHaveBeenCalledWith(
+            endpoint,
+            expect.objectContaining({
+                headers: expect.objectContaining({
+                    Authorization: 'Bearer token-value',
+                }),
+            }),
+        );
+    });
+
+    type MalformedBodyScenario = {
+        body: string,
+        status: number,
+    };
+
+    it.each<[string, MalformedBodyScenario]>(
+        Object.entries<MalformedBodyScenario>({
+            'report a gateway error as it came': {
+                body: 'upstream connect error or disconnect/reset before headers. '
+                    + 'reset reason: connection termination',
+                status: 503,
+            },
+            'report an HTML error page as it came': {
+                body: '<html><body><h1>502 Bad Gateway</h1></body></html>',
+                status: 502,
+            },
+            'report an empty body as it came': {
+                body: '',
+                status: 500,
+            },
+            'report a payload that is not an object as it came': {
+                body: 'null',
+                status: 200,
+            },
+        }),
+    )('should %s', async (_, scenario) => {
+        const {body, status} = scenario;
+
+        jest.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(body, {status: status}));
+
+        const client = new FetchGraphqlClient({endpoint: endpoint});
+
+        const error = await client.execute(query).catch(reason => reason);
+
+        expect(error).toBeInstanceOf(ApiError);
+        expect(error.message).toBe(body);
+    });
+
+    it('should report the errors of a non-successful response', async () => {
+        jest.spyOn(globalThis, 'fetch').mockResolvedValue(
+            Response.json(
+                {
+                    errors: [
+                        {
+                            message: 'Invalid input',
+                            extensions: {
+                                type: ProblemType.INVALID_INPUT,
+                                title: 'Invalid input',
+                                detail: 'Cannot query field "greeting" on type "Query".',
+                                status: 400,
+                            },
+                        },
+                    ],
+                },
+                {status: 400},
+            ),
+        );
+
+        const client = new FetchGraphqlClient({endpoint: endpoint});
+
+        const error = await client.execute(query).catch(reason => reason);
+
+        expect(error).toBeInstanceOf(ApiError);
+        expect(error.message).toBe('Invalid input');
+        expect(error.isErrorType(ProblemType.INVALID_INPUT)).toBe(true);
+        expect(error.problems[0].detail).toBe('Cannot query field `greeting` on type `Query`.');
+    });
+});


### PR DESCRIPTION
## Problem

The GraphQL client called `response.json()` on every response, whatever came back:

```ts
return response.json().then(result => { ... });
```

When the API is behind a gateway that answers with a plain-text error — an Envoy 503 whose body is `upstream connect error or disconnect/reset before headers. reset reason: connection termination` — the parse blows up and the CLI prints:

```
╭────────────────────── Unexpected error ──────────────────────╮
│  Unexpected token 'u', "upstream c"... is not valid JSON     │
│  › JSON.parse (<anonymous>)                                  │
│  › parseJSONFromBytes (node:internal/deps/undici/undici)     │
╰──────────────────────────────────────────────────────────────╯
```

That message names neither the status nor the failure, and the body is discarded before anything reaches the user. V8 reveals only the first 10 characters of the input, so `upstream c` is all that survives — not enough to tell a connection reset from a circuit breaker or a rate limit.

This surfaced in a downstream project whose CI hit a transient gateway error during `npm ci`. The parse error was the only clue, and it pointed nowhere near the cause.

## Change

The body is read as text and parsed explicitly. A body that is not a JSON object is reported as it came, so the gateway's own message reaches the user.

## Why not check `response.ok`

Checking the status looks simpler but breaks the structured error path. Probing the API directly:

| Request | Status | Body |
|---|---|---|
| Valid query | 200 | `{"data":{...}}` |
| Unknown field | **400** | `{"errors":[{"extensions":{"type":"...#invalid-input","status":400,...}}]}` |
| Inaccessible resource | **200** | `{"errors":[{"extensions":{"type":"...#access-denied","status":403,...}}]}` |

A `!response.ok` guard would throw on the 400 before the payload is read, discarding the `Problem` — its type, detail and violations — and replacing `Invalid input` with a raw JSON dump. It would also miss the access-denied case entirely, since that arrives as 200. The status simply does not indicate whether the body carries structured errors, so the check is on the payload instead. A test pins the 400-with-payload behaviour so the regression cannot be reintroduced quietly.

## Tests

`test/infrastructure/graphql/fetchGraphqlClient.test.ts` is new — the client had no test file. It covers the gateway error, an HTML error page, an empty body, a non-object payload, the 400-with-payload path, and the existing valid-payload and token-provider behaviour. `fetchGraphqlClient.ts` is at 100% coverage.

## Validation

`npm run validate`, `npm run build`, `npm test` (621 passed, 38 suites) and `npm run lint` all pass.

## Out of scope

Two related issues remain, both outside this change:

- The CLI **exits 0** after printing this error, so a `postinstall` chained with `&&` carries on and `npm ci` reports success with a broken tree.
- `node_modules/@croct/content` is cleared before fetching, so a failed run leaves the tree emptier than it found it.

Together those turn a transient gateway blip into a green install that fails much later with an unrelated-looking error. Happy to follow up on either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)