### PR TITLE
Detect platforms in packages without a name

### DIFF
--- a/src/application/project/packageManager/nodePackageManager.ts
+++ b/src/application/project/packageManager/nodePackageManager.ts
@@ -24,7 +24,7 @@ export type Configuration = {
 };
 
 export type PartialNpmManifest = {
-    name: string,
+    name?: string,
     version?: string,
     dependencies?: Record<string, string>,
     devDependencies?: Record<string, string>,
@@ -128,7 +128,7 @@ export class NodePackageManager implements PackageManager {
         }
 
         return {
-            name: info.name,
+            name: info.name ?? name,
             version: info.version ?? null,
             directory: this.fileSystem.getDirectoryName(manifestPath),
             metadata: info,

--- a/src/infrastructure/application/validation/partialNpmPackageValidator.ts
+++ b/src/infrastructure/application/validation/partialNpmPackageValidator.ts
@@ -4,7 +4,7 @@ import {ZodValidator} from '@/infrastructure/application/validation/zodValidator
 import type {PartialNpmManifest} from '@/application/project/packageManager/nodePackageManager';
 
 const packageSchema: ZodType<PartialNpmManifest> = z.object({
-    name: z.string(),
+    name: z.string().optional(),
     version: z.string().optional(),
     dependencies: z.record(z.string()).optional(),
     devDependencies: z.record(z.string()).optional(),


### PR DESCRIPTION
The npm manifest schema required `name`, so a `package.json` without one (common in private apps) failed validation and `readManifest` returned `null`. Every dependency check then reported `false`, and detection fell through to the `JAVASCRIPT` candidate, whose predicate only checks that `package.json` exists.

A Nuxt app was reported as a plain JS project. The same applied to Next.js, React, Vue and Hydrogen, as well as to `getScripts` and server command detection.

`name` is now optional, matching the Composer manifest schema, and `getDependency` falls back to the requested name.