### PR TITLE
Support the Nuxt 4 app directory and custom Storyblok plugins

### DIFF
--- a/src/application/project/code/transformation/javascript/nuxtConfigModuleCodemod.ts
+++ b/src/application/project/code/transformation/javascript/nuxtConfigModuleCodemod.ts
@@ -94,7 +94,13 @@ export class NuxtConfigModuleCodemod implements Codemod<t.File, CodemodOptions> 
         return false;
     }
 
-    private static findConfig(ast: t.File): t.ObjectExpression | null {
+    /**
+     * Locates the object literal holding the Nuxt configuration.
+     *
+     * @param ast The parsed configuration file.
+     * @returns The configuration object, or null if it cannot be statically resolved.
+     */
+    public static findConfig(ast: t.File): t.ObjectExpression | null {
         const defineName = NuxtConfigModuleCodemod.resolveDefineName(ast);
 
         let configObject: t.ObjectExpression | null = null;

--- a/src/application/project/code/transformation/javascript/nuxtConfigParser.ts
+++ b/src/application/project/code/transformation/javascript/nuxtConfigParser.ts
@@ -1,0 +1,103 @@
+import * as t from '@babel/types';
+import type {NodePath} from '@babel/core';
+import {traverse} from '@babel/core';
+import {parse} from '@/application/project/code/transformation/javascript/utils/parse';
+import {NuxtConfigModuleCodemod} from '@/application/project/code/transformation/javascript/nuxtConfigModuleCodemod';
+
+export type NuxtConfig = {
+    srcDir?: string,
+    future?: {
+        compatibilityVersion?: number,
+    },
+};
+
+/**
+ * Parses the Nuxt configuration options that determine the project layout.
+ *
+ * The extraction is static and best-effort: an option is only reported when
+ * its value can be evaluated without running the configuration, such as
+ * literals and references to constants.
+ */
+export class NuxtConfigParser {
+    public parse(source: string): NuxtConfig {
+        let ast: t.File;
+
+        try {
+            ast = parse(source, ['typescript']);
+        } catch {
+            return {};
+        }
+
+        const config = NuxtConfigModuleCodemod.findConfig(ast);
+
+        if (config === null) {
+            return {};
+        }
+
+        const result: NuxtConfig = {};
+
+        traverse(ast, {
+            ObjectExpression: path => {
+                if (path.node !== config) {
+                    return;
+                }
+
+                const srcDir = NuxtConfigParser.evaluateProperty(path, 'srcDir');
+
+                if (typeof srcDir === 'string') {
+                    result.srcDir = srcDir;
+                }
+
+                const future = NuxtConfigParser.findProperty(path, 'future')?.get('value');
+
+                if (future !== undefined && future.isObjectExpression()) {
+                    const version = NuxtConfigParser.evaluateProperty(future, 'compatibilityVersion');
+
+                    if (typeof version === 'number') {
+                        result.future = {
+                            compatibilityVersion: version,
+                        };
+                    }
+                }
+
+                path.stop();
+            },
+        });
+
+        return result;
+    }
+
+    private static evaluateProperty(object: NodePath<t.ObjectExpression>, name: string): unknown {
+        const evaluation = NuxtConfigParser.findProperty(object, name)
+            ?.get('value')
+            .evaluate();
+
+        return evaluation?.confident === true ? evaluation.value : undefined;
+    }
+
+    private static findProperty(
+        object: NodePath<t.ObjectExpression>,
+        name: string,
+    ): NodePath<t.ObjectProperty> | null {
+        let match: NodePath<t.ObjectProperty> | null = null;
+
+        // Later properties override earlier ones, as in the evaluated object
+        for (const property of object.get('properties')) {
+            if (
+                property.isObjectProperty()
+                && !property.node.computed
+                && NuxtConfigParser.hasKey(property.node, name)
+            ) {
+                match = property;
+            }
+        }
+
+        return match;
+    }
+
+    private static hasKey(property: t.ObjectProperty, name: string): boolean {
+        const {key} = property;
+
+        return (t.isIdentifier(key) && key.name === name) || (t.isStringLiteral(key) && key.value === name);
+    }
+}

--- a/src/application/project/code/transformation/javascript/nuxtStoryblokPluginCodemod.ts
+++ b/src/application/project/code/transformation/javascript/nuxtStoryblokPluginCodemod.ts
@@ -9,6 +9,7 @@ export type NuxtStoryblokPluginConfiguration = {
         module: string,
         factory: string,
     },
+    pluginName: string,
     storyblokVueModule: string,
     nuxtAppModule: string,
 };
@@ -16,9 +17,12 @@ export type NuxtStoryblokPluginConfiguration = {
 /**
  * Scaffolds the Croct Storyblok plugin file for Nuxt.
  *
- * Generates the canonical plugin body that wires the Storyblok API into Croct
- * inside a defineNuxtPlugin callback. Leaves hand-edited files untouched: if a
- * plugin definition is already present, the codemod returns unmodified.
+ * Generates the canonical plugin that wires the Storyblok API into Croct.
+ * The plugin runs after the regular ones because the Storyblok API may be
+ * installed by an application plugin (e.g., `storyblok.ts`) rather than by
+ * the Storyblok module, and Nuxt runs application plugins in filename order.
+ * Leaves hand-edited files untouched: if the file already has a default
+ * export or a plugin definition, the codemod returns unmodified.
  */
 export class NuxtStoryblokPluginCodemod implements Codemod<t.File, CodemodOptions> {
     private readonly configuration: NuxtStoryblokPluginConfiguration;
@@ -50,7 +54,9 @@ export class NuxtStoryblokPluginCodemod implements Codemod<t.File, CodemodOption
             importName: 'defineNuxtPlugin',
         });
 
-        const pluginCallback = t.arrowFunctionExpression(
+        const setupMethod = t.objectMethod(
+            'method',
+            t.identifier('setup'),
             [t.identifier('nuxtApp')],
             t.blockStatement([
                 t.expressionStatement(
@@ -68,10 +74,16 @@ export class NuxtStoryblokPluginCodemod implements Codemod<t.File, CodemodOption
             ]),
         );
 
+        const pluginDefinition = t.objectExpression([
+            t.objectProperty(t.identifier('name'), t.stringLiteral(this.configuration.pluginName)),
+            t.objectProperty(t.identifier('enforce'), t.stringLiteral('post')),
+            setupMethod,
+        ]);
+
         const defaultExport = t.exportDefaultDeclaration(
             t.callExpression(
                 t.identifier(defineNuxtPluginImport.localName),
-                [pluginCallback],
+                [pluginDefinition],
             ),
         );
 
@@ -91,6 +103,21 @@ export class NuxtStoryblokPluginCodemod implements Codemod<t.File, CodemodOption
         let found = false;
 
         traverse(ast, {
+            // A default export is the file's plugin, whatever its form
+            ExportDefaultDeclaration: path => {
+                found = true;
+
+                path.stop();
+            },
+            ExportSpecifier: path => {
+                const {exported} = path.node;
+
+                if ((t.isIdentifier(exported) ? exported.name : exported.value) === 'default') {
+                    found = true;
+
+                    path.stop();
+                }
+            },
             CallExpression: path => {
                 const {callee} = path.node;
 

--- a/src/application/project/sdk/javasScriptSdk.ts
+++ b/src/application/project/sdk/javasScriptSdk.ts
@@ -47,6 +47,7 @@ export type JavaScriptPluginContext = {
     packageManager: PackageManager,
     projectDirectory: WorkingDirectory,
     fileSystem: FileSystem,
+    paths: ProjectPaths,
 };
 
 export type JavaScriptSdkPlugin = {
@@ -318,13 +319,16 @@ export abstract class JavaScriptSdk implements Sdk {
         return defaultPath;
     }
 
-    private resolveInstallationPlan(installation: Installation): Promise<InstallationPlan> {
-        let promise = this.getInstallationPlan(installation);
+    private async resolveInstallationPlan(installation: Installation): Promise<InstallationPlan> {
+        const sdkPlan = await this.getInstallationPlan(installation);
         const context: JavaScriptPluginContext = {
             packageManager: this.packageManager,
             projectDirectory: this.projectDirectory,
             fileSystem: this.fileSystem,
+            paths: await this.getPaths(sdkPlan.configuration),
         };
+
+        let promise = Promise.resolve(sdkPlan);
 
         for (const plugin of this.plugins) {
             promise = promise.then(async plan => {

--- a/src/application/project/sdk/nuxtStoryblokPlugin.ts
+++ b/src/application/project/sdk/nuxtStoryblokPlugin.ts
@@ -49,8 +49,8 @@ export class NuxtStoryblokPlugin implements JavaScriptSdkPlugin {
     }
 
     private async scaffoldPluginFile(scope: JavaScriptPluginContext): Promise<void> {
-        const {fileSystem, projectDirectory} = scope;
-        const path = fileSystem.joinPaths(projectDirectory.get(), this.configuration.pluginFile);
+        const {fileSystem, projectDirectory, paths} = scope;
+        const path = fileSystem.joinPaths(projectDirectory.get(), paths.source, this.configuration.pluginFile);
 
         if (!await fileSystem.exists(path)) {
             await fileSystem.createDirectory(fileSystem.getDirectoryName(path), {recursive: true});

--- a/src/application/project/sdk/plugNuxtSdk.ts
+++ b/src/application/project/sdk/plugNuxtSdk.ts
@@ -17,6 +17,11 @@ import type {Example} from '@/application/project/example/example';
 import {UrlExample} from '@/application/project/example/example';
 import {ApiKeyPermission} from '@/application/model/application';
 import type {CommandExecutor} from '@/application/system/process/executor';
+import type {ProjectConfiguration, ProjectPaths} from '@/application/project/configuration/projectConfiguration';
+import type {
+    NuxtConfig,
+    NuxtConfigParser,
+} from '@/application/project/code/transformation/javascript/nuxtConfigParser';
 
 type CodemodConfiguration = {
     config: Codemod<string>,
@@ -24,6 +29,7 @@ type CodemodConfiguration = {
 
 export type Configuration = JavaScriptSdkConfiguration & {
     codemod: CodemodConfiguration,
+    configParser: NuxtConfigParser,
     userApi: UserApi,
     workspaceApi: WorkspaceApi,
     applicationApi: ApplicationApi,
@@ -49,11 +55,15 @@ enum NuxtEnvVar {
 }
 
 export class PlugNuxtSdk extends JavaScriptSdk {
+    private static readonly CONFIG_FILES = ['ts', 'js', 'mjs'].map(extension => `nuxt.config.${extension}`);
+
     private readonly userApi: UserApi;
 
     private readonly applicationApi: ApplicationApi;
 
     private readonly codemod: CodemodConfiguration;
+
+    private readonly configParser: NuxtConfigParser;
 
     private readonly commandExecutor: CommandExecutor;
 
@@ -61,9 +71,24 @@ export class PlugNuxtSdk extends JavaScriptSdk {
         super(configuration);
 
         this.codemod = configuration.codemod;
+        this.configParser = configuration.configParser;
         this.userApi = configuration.userApi;
         this.applicationApi = configuration.applicationApi;
         this.commandExecutor = configuration.commandExecutor;
+    }
+
+    public async getPaths(configuration: ProjectConfiguration): Promise<ProjectPaths> {
+        const source = configuration.paths?.source ?? await this.getSourceDirectory();
+
+        return super.getPaths({
+            ...configuration,
+            paths: {
+                ...configuration.paths,
+                source: source,
+                // Examples are pages, which Nuxt routes automatically
+                examples: configuration.paths?.examples ?? this.fileSystem.joinPaths(source, 'pages'),
+            },
+        });
     }
 
     protected createExample(slot: Slot): Promise<Example> {
@@ -81,7 +106,12 @@ export class PlugNuxtSdk extends JavaScriptSdk {
         const generator = new PlugNuxtExampleGenerator({
             typescript: isTypeScript,
             contentVariable: 'data.content',
-            slotImportPath: this.fileSystem.joinPaths('~', paths.components, '%slug%.vue'),
+            // Nuxt resolves `~` to the source directory
+            slotImportPath: this.fileSystem.joinPaths(
+                '~',
+                this.fileSystem.getRelativePath(paths.source, paths.components),
+                '%slug%.vue',
+            ),
             slotFilePath: slotPath,
             slotComponentName: '%name%',
             pageFilePath: pagePath,
@@ -106,13 +136,7 @@ export class PlugNuxtSdk extends JavaScriptSdk {
                 ...installation,
                 project: projectInfo,
             }),
-            configuration: {
-                ...configuration,
-                paths: {
-                    ...configuration.paths,
-                    examples: 'pages',
-                },
-            },
+            configuration: configuration,
         };
     }
 
@@ -138,9 +162,69 @@ export class PlugNuxtSdk extends JavaScriptSdk {
     }
 
     private async locateNuxtConfig(): Promise<string | null> {
-        return this.locateFile(
-            ...['ts', 'js', 'mjs'].map(ext => `nuxt.config.${ext}`),
+        return this.locateFile(...PlugNuxtSdk.CONFIG_FILES);
+    }
+
+    private async getConfig(): Promise<NuxtConfig> {
+        const source = await this.readFile(...PlugNuxtSdk.CONFIG_FILES).catch(() => null);
+
+        return source === null ? {} : this.configParser.parse(source);
+    }
+
+    /**
+     * Resolves the source directory following the rules Nuxt applies to `srcDir`.
+     *
+     * Unless configured otherwise, Nuxt 4, and Nuxt 3 opted into the version 4
+     * behavior, use `app/` as the source directory, falling back to the root
+     * directory for projects that still follow the previous layout.
+     */
+    private async getSourceDirectory(): Promise<string> {
+        const [config, isNuxt4] = await Promise.all([
+            this.getConfig(),
+            // Includes the 4.0 pre-releases
+            this.packageManager.hasDirectDependency('nuxt', '>=4.0.0-0'),
+        ]);
+
+        if (config.srcDir !== undefined) {
+            const root = this.projectDirectory.get();
+            const directory = this.fileSystem.getRelativePath(root, this.fileSystem.joinPaths(root, config.srcDir));
+
+            return directory === '' ? '.' : directory;
+        }
+
+        if (!isNuxt4 && config.future?.compatibilityVersion !== 4) {
+            return '.';
+        }
+
+        return await this.usesAppDirectory() ? 'app' : '.';
+    }
+
+    private async usesAppDirectory(): Promise<boolean> {
+        const directory = this.fileSystem.joinPaths(this.projectDirectory.get(), 'app');
+
+        if (!await this.fileSystem.isDirectory(directory)) {
+            return false;
+        }
+
+        for await (const entry of this.fileSystem.list(directory, (_, depth) => depth === 0)) {
+            // Nuxt 3 already kept these files in `app/`, so they do not indicate the new layout
+            if (entry.name !== 'spa-loading-template.html' && !entry.name.startsWith('router.options')) {
+                return true;
+            }
+        }
+
+        // Otherwise, `app/` is the source directory unless the root follows the previous layout
+        const rootLayoutEntry = await this.locateFile(
+            'app.vue',
+            'App.vue',
+            'assets',
+            'layouts',
+            'middleware',
+            'pages',
+            'plugins',
         );
+
+        return rootLayoutEntry === null;
     }
 
     private getInstallationTasks(installation: Omit<NuxtInstallation, 'notifier'>): Task[] {

--- a/src/infrastructure/application/cli/cli.ts
+++ b/src/infrastructure/application/cli/cli.ts
@@ -379,6 +379,7 @@ import {NuxtStoryblokPlugin} from '@/application/project/sdk/nuxtStoryblokPlugin
 import {VuePluginCodemod} from '@/application/project/code/transformation/javascript/vuePluginCodemod';
 import {VueStoryblokCodemod} from '@/application/project/code/transformation/javascript/vueStoryblokCodemod';
 import {NuxtConfigModuleCodemod} from '@/application/project/code/transformation/javascript/nuxtConfigModuleCodemod';
+import {NuxtConfigParser} from '@/application/project/code/transformation/javascript/nuxtConfigParser';
 import {ViteConfigPluginCodemod} from '@/application/project/code/transformation/javascript/viteConfigPluginCodemod';
 import {
     HydrogenMiddlewareCodemod,
@@ -1901,6 +1902,7 @@ export class Cli {
                     [Platform.NUXT]: (): Sdk => new PlugNuxtSdk({
                         ...config,
                         plugins: [this.createNuxtStoryblokPlugin()],
+                        configParser: new NuxtConfigParser(),
                         userApi: this.getUserApi(),
                         applicationApi: this.getApplicationApi(),
                         commandExecutor: this.getAsynchronousCommandExecutor(),
@@ -2303,6 +2305,7 @@ export class Cli {
                                 module: '@croct/plug-storyblok/nuxt',
                                 factory: 'withCroct',
                             },
+                            pluginName: 'croct-storyblok',
                             storyblokVueModule: '@storyblok/vue',
                             nuxtAppModule: '#app',
                         }),

--- a/test/application/project/code/transformation/fixtures/nuxt-config/aliasedDefineCall.ts
+++ b/test/application/project/code/transformation/fixtures/nuxt-config/aliasedDefineCall.ts
@@ -1,0 +1,8 @@
+import {defineNuxtConfig as defineConfig} from 'nuxt/config';
+
+export default defineConfig({
+    srcDir: 'src',
+    future: {
+        compatibilityVersion: 4,
+    },
+});

--- a/test/application/project/code/transformation/fixtures/nuxt-config/bareObjectExport.ts
+++ b/test/application/project/code/transformation/fixtures/nuxt-config/bareObjectExport.ts
@@ -1,0 +1,6 @@
+export default {
+    srcDir: 'src',
+    future: {
+        compatibilityVersion: 4,
+    },
+};

--- a/test/application/project/code/transformation/fixtures/nuxt-config/commonJsExport.js
+++ b/test/application/project/code/transformation/fixtures/nuxt-config/commonJsExport.js
@@ -1,0 +1,6 @@
+module.exports = {
+    srcDir: 'src',
+    future: {
+        compatibilityVersion: 4,
+    },
+};

--- a/test/application/project/code/transformation/fixtures/nuxt-config/compatibilityVersionOnly.ts
+++ b/test/application/project/code/transformation/fixtures/nuxt-config/compatibilityVersionOnly.ts
@@ -1,0 +1,5 @@
+export default defineNuxtConfig({
+    future: {
+        compatibilityVersion: 4,
+    },
+});

--- a/test/application/project/code/transformation/fixtures/nuxt-config/constantReferences.ts
+++ b/test/application/project/code/transformation/fixtures/nuxt-config/constantReferences.ts
@@ -1,0 +1,9 @@
+const sourceDirectory = 'src';
+const version = 4;
+
+export default defineNuxtConfig({
+    srcDir: sourceDirectory,
+    future: {
+        compatibilityVersion: version,
+    },
+});

--- a/test/application/project/code/transformation/fixtures/nuxt-config/defineCall.ts
+++ b/test/application/project/code/transformation/fixtures/nuxt-config/defineCall.ts
@@ -1,0 +1,6 @@
+export default defineNuxtConfig({
+    srcDir: 'src',
+    future: {
+        compatibilityVersion: 4,
+    },
+});

--- a/test/application/project/code/transformation/fixtures/nuxt-config/defineCallWithReference.ts
+++ b/test/application/project/code/transformation/fixtures/nuxt-config/defineCallWithReference.ts
@@ -1,0 +1,8 @@
+const options = {
+    srcDir: 'src',
+    future: {
+        compatibilityVersion: 4,
+    },
+};
+
+export default defineNuxtConfig(options);

--- a/test/application/project/code/transformation/fixtures/nuxt-config/duplicateProperties.ts
+++ b/test/application/project/code/transformation/fixtures/nuxt-config/duplicateProperties.ts
@@ -1,0 +1,8 @@
+export default defineNuxtConfig({
+    srcDir: 'app',
+    future: {
+        compatibilityVersion: 3,
+        compatibilityVersion: 4,
+    },
+    srcDir: 'src',
+});

--- a/test/application/project/code/transformation/fixtures/nuxt-config/ignoredProperties.ts
+++ b/test/application/project/code/transformation/fixtures/nuxt-config/ignoredProperties.ts
@@ -1,0 +1,13 @@
+const base = {srcDir: 'base'};
+
+export default defineNuxtConfig({
+    ...base,
+    ['srcDir']: 'computed',
+    1: 'numeric',
+    hooks() {},
+    srcDir: 'src',
+    future: {
+        ...base,
+        compatibilityVersion: 4,
+    },
+});

--- a/test/application/project/code/transformation/fixtures/nuxt-config/indirectConfigVariable.ts
+++ b/test/application/project/code/transformation/fixtures/nuxt-config/indirectConfigVariable.ts
@@ -1,0 +1,8 @@
+const config = defineNuxtConfig({
+    srcDir: 'src',
+    future: {
+        compatibilityVersion: 4,
+    },
+});
+
+export default config;

--- a/test/application/project/code/transformation/fixtures/nuxt-config/invalidCode.js
+++ b/test/application/project/code/transformation/fixtures/nuxt-config/invalidCode.js
@@ -1,0 +1,2 @@
+export default defineNuxtConfig({
+    srcDir: 'src',

--- a/test/application/project/code/transformation/fixtures/nuxt-config/invalidOptionTypes.ts
+++ b/test/application/project/code/transformation/fixtures/nuxt-config/invalidOptionTypes.ts
@@ -1,0 +1,6 @@
+export default defineNuxtConfig({
+    srcDir: false,
+    future: {
+        compatibilityVersion: '4',
+    },
+});

--- a/test/application/project/code/transformation/fixtures/nuxt-config/nestedOptions.ts
+++ b/test/application/project/code/transformation/fixtures/nuxt-config/nestedOptions.ts
@@ -1,0 +1,5 @@
+export default defineNuxtConfig({
+    modules: [
+        ['some-module', {srcDir: 'src', future: {compatibilityVersion: 4}}],
+    ],
+});

--- a/test/application/project/code/transformation/fixtures/nuxt-config/noLayoutOptions.ts
+++ b/test/application/project/code/transformation/fixtures/nuxt-config/noLayoutOptions.ts
@@ -1,0 +1,3 @@
+export default defineNuxtConfig({
+    modules: ['@croct/plug-nuxt'],
+});

--- a/test/application/project/code/transformation/fixtures/nuxt-config/nonLiteralValues.ts
+++ b/test/application/project/code/transformation/fixtures/nuxt-config/nonLiteralValues.ts
@@ -1,0 +1,8 @@
+import {fileURLToPath} from 'node:url';
+
+export default defineNuxtConfig({
+    srcDir: fileURLToPath(new URL('./src', import.meta.url)),
+    future: {
+        compatibilityVersion: Number(process.env.NUXT_COMPATIBILITY_VERSION),
+    },
+});

--- a/test/application/project/code/transformation/fixtures/nuxt-config/nonObjectFuture.ts
+++ b/test/application/project/code/transformation/fixtures/nuxt-config/nonObjectFuture.ts
@@ -1,0 +1,6 @@
+import {future} from './shared';
+
+export default defineNuxtConfig({
+    srcDir: 'src',
+    future: future,
+});

--- a/test/application/project/code/transformation/fixtures/nuxt-config/srcDirOnly.ts
+++ b/test/application/project/code/transformation/fixtures/nuxt-config/srcDirOnly.ts
@@ -1,0 +1,3 @@
+export default defineNuxtConfig({
+    srcDir: 'src',
+});

--- a/test/application/project/code/transformation/fixtures/nuxt-config/stringKeys.ts
+++ b/test/application/project/code/transformation/fixtures/nuxt-config/stringKeys.ts
@@ -1,0 +1,6 @@
+export default defineNuxtConfig({
+    'srcDir': 'src',
+    'future': {
+        'compatibilityVersion': 4,
+    },
+});

--- a/test/application/project/code/transformation/fixtures/nuxt-config/templateLiteral.ts
+++ b/test/application/project/code/transformation/fixtures/nuxt-config/templateLiteral.ts
@@ -1,0 +1,6 @@
+export default defineNuxtConfig({
+    srcDir: `src`,
+    future: {
+        compatibilityVersion: 4,
+    },
+});

--- a/test/application/project/code/transformation/fixtures/nuxt-config/withTypeAssertion.ts
+++ b/test/application/project/code/transformation/fixtures/nuxt-config/withTypeAssertion.ts
@@ -1,0 +1,8 @@
+import type {NuxtConfig} from 'nuxt/schema';
+
+export default {
+    srcDir: 'src',
+    future: {
+        compatibilityVersion: 4,
+    },
+} satisfies NuxtConfig;

--- a/test/application/project/code/transformation/fixtures/nuxt-storyblok-plugin/alreadyScaffoldedObjectSyntax.ts
+++ b/test/application/project/code/transformation/fixtures/nuxt-storyblok-plugin/alreadyScaffoldedObjectSyntax.ts
@@ -1,0 +1,11 @@
+import { withCroct } from '@croct/plug-storyblok/nuxt';
+import { useStoryblokApi } from '@storyblok/vue';
+import { defineNuxtPlugin } from '#app';
+
+export default defineNuxtPlugin({
+    name: 'croct-storyblok',
+    enforce: 'post',
+    setup(nuxtApp) {
+        withCroct(nuxtApp, useStoryblokApi());
+    },
+});

--- a/test/application/project/code/transformation/fixtures/nuxt-storyblok-plugin/defaultExportSpecifier.ts
+++ b/test/application/project/code/transformation/fixtures/nuxt-storyblok-plugin/defaultExportSpecifier.ts
@@ -1,0 +1,3 @@
+const plugin = () => {};
+
+export {plugin as default};

--- a/test/application/project/code/transformation/fixtures/nuxt-storyblok-plugin/existingDefaultExport.ts
+++ b/test/application/project/code/transformation/fixtures/nuxt-storyblok-plugin/existingDefaultExport.ts
@@ -1,0 +1,3 @@
+const options = {};
+
+export default options;

--- a/test/application/project/code/transformation/fixtures/nuxt-storyblok-plugin/importsOnly.ts
+++ b/test/application/project/code/transformation/fixtures/nuxt-storyblok-plugin/importsOnly.ts
@@ -1,0 +1,2 @@
+import {withCroct} from '@croct/plug-storyblok/nuxt';
+import {useStoryblokApi} from '@storyblok/vue';

--- a/test/application/project/code/transformation/fixtures/nuxt-storyblok-plugin/namedExport.ts
+++ b/test/application/project/code/transformation/fixtures/nuxt-storyblok-plugin/namedExport.ts
@@ -1,0 +1,3 @@
+const helper = () => {};
+
+export {helper};

--- a/test/application/project/code/transformation/fixtures/nuxt-storyblok-plugin/namedPluginExport.ts
+++ b/test/application/project/code/transformation/fixtures/nuxt-storyblok-plugin/namedPluginExport.ts
@@ -1,0 +1,3 @@
+import {defineNuxtPlugin} from 'nuxt/app';
+
+export const plugin = defineNuxtPlugin(() => {});

--- a/test/application/project/code/transformation/fixtures/nuxt-storyblok-plugin/stringDefaultExportSpecifier.ts
+++ b/test/application/project/code/transformation/fixtures/nuxt-storyblok-plugin/stringDefaultExportSpecifier.ts
@@ -1,0 +1,3 @@
+const plugin = () => {};
+
+export {plugin as 'default'};

--- a/test/application/project/code/transformation/fixtures/nuxt-storyblok-plugin/unrelatedCalls.ts
+++ b/test/application/project/code/transformation/fixtures/nuxt-storyblok-plugin/unrelatedCalls.ts
@@ -1,0 +1,2 @@
+console.log('Croct');
+setup();

--- a/test/application/project/code/transformation/javascript/__snapshots__/nuxtStoryblokPluginCodemod.test.ts.snap
+++ b/test/application/project/code/transformation/javascript/__snapshots__/nuxtStoryblokPluginCodemod.test.ts.snap
@@ -20,14 +20,89 @@ export default defineNuxtPlugin(nuxtApp => {
 "
 `;
 
+exports[`NuxtStoryblokPluginCodemod should correctly transform alreadyScaffoldedObjectSyntax.ts: alreadyScaffoldedObjectSyntax.ts 1`] = `
+"import { withCroct } from '@croct/plug-storyblok/nuxt';
+import { useStoryblokApi } from '@storyblok/vue';
+import { defineNuxtPlugin } from '#app';
+
+export default defineNuxtPlugin({
+    name: 'croct-storyblok',
+    enforce: 'post',
+    setup(nuxtApp) {
+        withCroct(nuxtApp, useStoryblokApi());
+    },
+});
+"
+`;
+
+exports[`NuxtStoryblokPluginCodemod should correctly transform defaultExportSpecifier.ts: defaultExportSpecifier.ts 1`] = `
+"const plugin = () => {};
+
+export {plugin as default};
+"
+`;
+
 exports[`NuxtStoryblokPluginCodemod should correctly transform empty.ts: empty.ts 1`] = `
 "import { defineNuxtPlugin } from "#app";
 import { useStoryblokApi } from "@storyblok/vue";
 import { withCroct } from "@croct/plug-storyblok/nuxt";
 
-export default defineNuxtPlugin(nuxtApp => {
-  withCroct(nuxtApp, useStoryblokApi());
+export default defineNuxtPlugin({
+  name: "croct-storyblok",
+  enforce: "post",
+
+  setup(nuxtApp) {
+    withCroct(nuxtApp, useStoryblokApi());
+  }
 });"
+`;
+
+exports[`NuxtStoryblokPluginCodemod should correctly transform existingDefaultExport.ts: existingDefaultExport.ts 1`] = `
+"const options = {};
+
+export default options;
+"
+`;
+
+exports[`NuxtStoryblokPluginCodemod should correctly transform importsOnly.ts: importsOnly.ts 1`] = `
+"import { defineNuxtPlugin } from "#app";
+import {withCroct} from '@croct/plug-storyblok/nuxt';
+import {useStoryblokApi} from '@storyblok/vue';
+
+export default defineNuxtPlugin({
+  name: "croct-storyblok",
+  enforce: "post",
+
+  setup(nuxtApp) {
+    withCroct(nuxtApp, useStoryblokApi());
+  }
+});
+"
+`;
+
+exports[`NuxtStoryblokPluginCodemod should correctly transform namedExport.ts: namedExport.ts 1`] = `
+"import { defineNuxtPlugin } from "#app";
+import { useStoryblokApi } from "@storyblok/vue";
+import { withCroct } from "@croct/plug-storyblok/nuxt";
+const helper = () => {};
+export {helper};
+
+export default defineNuxtPlugin({
+  name: "croct-storyblok",
+  enforce: "post",
+
+  setup(nuxtApp) {
+    withCroct(nuxtApp, useStoryblokApi());
+  }
+});
+"
+`;
+
+exports[`NuxtStoryblokPluginCodemod should correctly transform namedPluginExport.ts: namedPluginExport.ts 1`] = `
+"import {defineNuxtPlugin} from 'nuxt/app';
+
+export const plugin = defineNuxtPlugin(() => {});
+"
 `;
 
 exports[`NuxtStoryblokPluginCodemod should correctly transform partialScaffold.ts: partialScaffold.ts 1`] = `
@@ -39,13 +114,43 @@ export default defineNuxtPlugin(nuxtApp => {
 "
 `;
 
+exports[`NuxtStoryblokPluginCodemod should correctly transform stringDefaultExportSpecifier.ts: stringDefaultExportSpecifier.ts 1`] = `
+"const plugin = () => {};
+
+export {plugin as 'default'};
+"
+`;
+
+exports[`NuxtStoryblokPluginCodemod should correctly transform unrelatedCalls.ts: unrelatedCalls.ts 1`] = `
+"import { defineNuxtPlugin } from "#app";
+import { useStoryblokApi } from "@storyblok/vue";
+import { withCroct } from "@croct/plug-storyblok/nuxt";
+console.log('Croct');
+setup();
+
+export default defineNuxtPlugin({
+  name: "croct-storyblok",
+  enforce: "post",
+
+  setup(nuxtApp) {
+    withCroct(nuxtApp, useStoryblokApi());
+  }
+});
+"
+`;
+
 exports[`NuxtStoryblokPluginCodemod should correctly transform withComments.ts: withComments.ts 1`] = `
 "import { defineNuxtPlugin } from "#app";
 import { useStoryblokApi } from "@storyblok/vue";
 import { withCroct } from "@croct/plug-storyblok/nuxt";
 
-export default defineNuxtPlugin(nuxtApp => {
-  withCroct(nuxtApp, useStoryblokApi());
+export default defineNuxtPlugin({
+  name: "croct-storyblok",
+  enforce: "post",
+
+  setup(nuxtApp) {
+    withCroct(nuxtApp, useStoryblokApi());
+  }
 });
 "
 `;

--- a/test/application/project/code/transformation/javascript/nuxtConfigParser.test.ts
+++ b/test/application/project/code/transformation/javascript/nuxtConfigParser.test.ts
@@ -1,0 +1,48 @@
+import {resolve} from 'path';
+import type {NuxtConfig} from '@/application/project/code/transformation/javascript/nuxtConfigParser';
+import {NuxtConfigParser} from '@/application/project/code/transformation/javascript/nuxtConfigParser';
+import {loadFixtures} from '../fixtures';
+
+describe('NuxtConfigParser', () => {
+    const layoutOptions: NuxtConfig = {
+        srcDir: 'src',
+        future: {
+            compatibilityVersion: 4,
+        },
+    };
+
+    // Fixtures without an expectation resolve no layout option
+    const scenarios = loadFixtures<NuxtConfig>(
+        resolve(__dirname, '../fixtures/nuxt-config'),
+        {},
+        {
+            'aliasedDefineCall.ts': layoutOptions,
+            'bareObjectExport.ts': layoutOptions,
+            'compatibilityVersionOnly.ts': {
+                future: {
+                    compatibilityVersion: 4,
+                },
+            },
+            'constantReferences.ts': layoutOptions,
+            'defineCall.ts': layoutOptions,
+            'duplicateProperties.ts': layoutOptions,
+            'ignoredProperties.ts': layoutOptions,
+            'indirectConfigVariable.ts': layoutOptions,
+            'nonObjectFuture.ts': {
+                srcDir: 'src',
+            },
+            'srcDirOnly.ts': {
+                srcDir: 'src',
+            },
+            'stringKeys.ts': layoutOptions,
+            'templateLiteral.ts': layoutOptions,
+            'withTypeAssertion.ts': layoutOptions,
+        },
+    );
+
+    it.each(scenarios)('should correctly parse $name', ({fixture, options: expected}) => {
+        const parser = new NuxtConfigParser();
+
+        expect(parser.parse(fixture)).toEqual(expected);
+    });
+});

--- a/test/application/project/code/transformation/javascript/nuxtStoryblokPluginCodemod.test.ts
+++ b/test/application/project/code/transformation/javascript/nuxtStoryblokPluginCodemod.test.ts
@@ -14,6 +14,7 @@ describe('NuxtStoryblokPluginCodemod', () => {
             module: '@croct/plug-storyblok/nuxt',
             factory: 'withCroct',
         },
+        pluginName: 'croct-storyblok',
         storyblokVueModule: '@storyblok/vue',
         nuxtAppModule: '#app',
     };


### PR DESCRIPTION
The CLI treated the project root as the Nuxt source directory. Nuxt 4 uses `app/`, and so does Nuxt 3 with `future.compatibilityVersion: 4`. So `croct init` wrote `plugins/croct-storyblok.ts` where Nuxt ignores it, silently disabling the Storyblok integration. It also recorded `components` and `examples` paths in `croct.json` that point at root directories Nuxt never loads, so `croct add slot` would scaffold files that are never picked up.

Separately, apps that set `usePlugin: false` and install Storyblok from their own plugin, like Storyblok's demo frontend, crashed on startup on both Nuxt 3 and 4. Nuxt runs application plugins in filename order, so `croct-storyblok.ts` ran before `storyblok.ts` and `useStoryblokApi()` threw.

Changes:

- `PlugNuxtSdk.getPaths()` resolves `source` with Nuxt's own `srcDir` rules. An explicit `srcDir` wins. Otherwise Nuxt 4, and Nuxt 3 on compatibility version 4, use `app/`, unless `app/` only holds files Nuxt 3 already kept there and the root still follows the previous layout. Components, utilities and examples derive from it.
- `NuxtConfigParser` statically reads `srcDir` and `future.compatibilityVersion` from `nuxt.config`, evaluating constants and template literals. It reuses the config lookup of `NuxtConfigModuleCodemod`.
- SDK plugins receive the resolved paths, and `NuxtStoryblokPlugin` scaffolds the plugin under the source directory.
- The scaffolded plugin declares `name: 'croct-storyblok'` and `enforce: 'post'`, so it runs after every regular plugin, whatever that plugin is named. `dependsOn` can't do this because the `@storyblok/nuxt` plugin is unnamed.
- The codemod now leaves files with any default export untouched. Before, it appended a second default export.

`croct.json` stays at the project root; only the paths it records change.

Both the parser and the codemod are covered at 100% by fixtures.

Validated by running `croct init` with this build on four fresh apps, then loading each in a headless browser and building for production:

| App | `paths.source` | Plugin | Page renders, Croct requests | Build |
|---|---|---|---|---|
| Nuxt 3, root layout, app-installed Storyblok | `.` | `plugins/` | ✔ | ✔ |
| Nuxt 3, compatibility version 4 | `app` | `app/plugins/` | ✔ | ✔ |
| Nuxt 4 | `app` | `app/plugins/` | ✔ | ✔ |
| Nuxt 4, app-installed Storyblok | `app` | `app/plugins/` | ✔ | ✔ |

Known limits: a config passed as a variable (`defineNuxtConfig(options)`) isn't resolved, same as in the module codemod, and a custom `dir.plugins` isn't honored.
