### PR TITLE
Honor the --cwd option

### DIFF
--- a/src/infrastructure/application/cli/program.ts
+++ b/src/infrastructure/application/cli/program.ts
@@ -22,14 +22,29 @@ function createProgram(config: Configuration): typeof program {
         .enablePositionalOptions()
         .option('--cwd <path>', 'The working directory.', path => {
             let directory: string;
+            let isDirectory: boolean;
 
             try {
                 directory = realpathSync(path);
-            } catch {
-                throw new InvalidOptionArgumentError('The path does not exist.');
+                isDirectory = statSync(directory).isDirectory();
+            } catch (error) {
+                const code = error instanceof Error && 'code' in error ? error.code : null;
+
+                switch (code) {
+                    case 'ENOENT':
+                    case 'ENOTDIR':
+                        throw new InvalidOptionArgumentError('The path does not exist.');
+
+                    case 'EACCES':
+                    case 'EPERM':
+                        throw new InvalidOptionArgumentError('The path is not accessible.');
+
+                    default:
+                        throw new InvalidOptionArgumentError('The path cannot be resolved.');
+                }
             }
 
-            if (!statSync(directory).isDirectory()) {
+            if (!isDirectory) {
                 throw new InvalidOptionArgumentError('The path is not a directory.');
             }
 

--- a/src/infrastructure/application/cli/program.ts
+++ b/src/infrastructure/application/cli/program.ts
@@ -1,6 +1,6 @@
 import {Argument, Command, InvalidOptionArgumentError, Option} from '@commander-js/extra-typings';
 import type {JsonPrimitive, JsonValue} from '@croct/json';
-import {realpathSync} from 'fs';
+import {realpathSync, statSync} from 'fs';
 import {ApiKey} from '@croct/sdk/apiKey';
 import {Token} from '@croct/sdk/token';
 import {Cli} from '@/infrastructure/application/cli/cli';
@@ -21,11 +21,19 @@ function createProgram(config: Configuration): typeof program {
         .description('Manage your Croct projects')
         .enablePositionalOptions()
         .option('--cwd <path>', 'The working directory.', path => {
+            let directory: string;
+
             try {
-                return realpathSync(path);
+                directory = realpathSync(path);
             } catch {
                 throw new InvalidOptionArgumentError('The path does not exist.');
             }
+
+            if (!statSync(directory).isDirectory()) {
+                throw new InvalidOptionArgumentError('The path is not a directory.');
+            }
+
+            return directory;
         })
         .addOption(
             new Option('--api-key <key>', 'The API key to use for authentication.')
@@ -457,6 +465,9 @@ export async function run(args: string[] = process.argv, welcome = true): Promis
             ? undefined
             : new URL(options.registry),
         configurationFile: options.config,
+        directories: {
+            current: options.cwd,
+        },
     });
 
     const template = getTemplate(invocation.args);


### PR DESCRIPTION
`--cwd` was declared and validated but never passed to the CLI, so every command still ran against the directory it was launched from. `croct --cwd app init`, for example, configured the launch directory instead of `app`: it wrote `croct.json` there, ran `npm install` there, and edited that directory's `package.json`.

`run()` now passes the option as `directories.current`, the starting directory `Cli` already supports. Without `--cwd` it still falls back to the process directory, so invocations without the flag behave as before.

The option also rejects a path that exists but isn't a directory. That used to be harmless because the value was ignored; now it would fail later with a confusing file-system error. Resolution errors are reported by cause, so a path that isn't accessible or can't be resolved (a symlink loop, for example) no longer reads as missing.

## Consequences

The value seeds the CLI's single working directory, so everything that already resolves against it now follows `--cwd`, as if the CLI had been started there:

- Project detection, `croct.json`, the package manager, the SDKs, the formatters, the import resolver and the local server.
- Spawned commands such as `npm install` and `nuxi prepare`, which take their working directory from the same object.
- Relative paths: `--config`, local templates (`croct use ./template.json5`) and every file-system operation resolve against `--cwd` rather than the launch directory.
- Templates: `change-directory` can't leave `--cwd`, which becomes the root they're confined to.
- The auto-updater: a CLI installed locally is updated in the `--cwd` project. A global install is unaffected.

Unchanged:

- `croct open` (deep links) still uses the real process directory, and the command it runs doesn't inherit `--cwd`. Nested runs have never forwarded global options.
- The option must still come before the command (`croct --cwd app init`), because the program uses positional options.
- A relative `--cwd` resolves against the launch directory, with symlinks resolved.

## Validation

Built the CLI and ran it against fresh copies of a Nuxt 4 app:

| Invocation | Result |
|---|---|
| `croct --cwd app init …`, launched from the parent directory | Nuxt detected; `croct.json`, `@croct/plug-nuxt`, the module and the Storyblok plugin all landed in `app`, and nothing was written to the launch directory |
| `croct init …`, launched inside a second copy | Identical result |
| `croct --cwd /nonexistent/dir …` | `The path does not exist.` |
| `croct --cwd app/package.json …` | `The path is not a directory.` |
| `croct --cwd <directory without permission> …` | `The path is not accessible.` |
| `croct --cwd <symlink loop> …` | `The path cannot be resolved.` |

`tsc`, lint and the test suite pass.
